### PR TITLE
feat: make scraper auto-only

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as instagramAccounts from "../instagramAccounts.js";
 import type * as keywords from "../keywords.js";
 import type * as lists from "../lists.js";
 import type * as messageTemplates from "../messageTemplates.js";
+import type * as migrations from "../migrations.js";
 import type * as profiles from "../profiles.js";
 import type * as scrapingTasks from "../scrapingTasks.js";
 import type * as workflows from "../workflows.js";
@@ -33,6 +34,7 @@ declare const fullApi: ApiFromModules<{
   keywords: typeof keywords;
   lists: typeof lists;
   messageTemplates: typeof messageTemplates;
+  migrations: typeof migrations;
   profiles: typeof profiles;
   scrapingTasks: typeof scrapingTasks;
   workflows: typeof workflows;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -41,7 +41,6 @@ function mapProfileToPython(profile: any): any {
 		proxy_type: profile.proxyType ?? null,
 		status: profile.status ?? null,
 		mode: profile.mode ?? null,
-		automation: typeof profile.automation === "boolean" ? profile.automation : false,
 		session_id: typeof profile.sessionId === "string" ? profile.sessionId : null,
 		Using: Boolean(profile.using),
 		test_ip: Boolean(profile.testIp),
@@ -244,7 +243,6 @@ http.route({
 				fingerprintSeed: body?.fingerprintSeed ?? body?.fingerprint_seed ?? undefined,
 				fingerprintOs: body?.fingerprintOs ?? body?.fingerprint_os ?? undefined,
 				testIp: body?.testIp ?? body?.test_ip ?? undefined,
-				automation: body?.automation ?? undefined,
 				sessionId: body?.sessionId ?? body?.session_id ?? undefined,
 				dailyScrapingLimit: body?.dailyScrapingLimit ?? body?.daily_scraping_limit ?? undefined,
 			});
@@ -271,7 +269,6 @@ http.route({
 				fingerprintSeed: body?.fingerprintSeed ?? body?.fingerprint_seed ?? undefined,
 				fingerprintOs: body?.fingerprintOs ?? body?.fingerprint_os ?? undefined,
 				testIp: body?.testIp ?? body?.test_ip ?? undefined,
-				automation: body?.automation ?? undefined,
 				sessionId: body?.sessionId ?? body?.session_id ?? undefined,
 				dailyScrapingLimit: body?.dailyScrapingLimit ?? body?.daily_scraping_limit ?? undefined,
 			} as any);
@@ -298,7 +295,6 @@ http.route({
 				fingerprintSeed: body?.fingerprintSeed ?? body?.fingerprint_seed ?? undefined,
 				fingerprintOs: body?.fingerprintOs ?? body?.fingerprint_os ?? undefined,
 				testIp: body?.testIp ?? body?.test_ip ?? undefined,
-				automation: body?.automation ?? undefined,
 				sessionId: body?.sessionId ?? body?.session_id ?? undefined,
 				dailyScrapingLimit: body?.dailyScrapingLimit ?? body?.daily_scraping_limit ?? undefined,
 			});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,196 @@
+import { v } from 'convex/values'
+import { mutation } from './_generated/server'
+
+const LEGACY_LAST_OUTPUT_KEYS = ['mode', 'distribution', 'profileId', 'limit'] as const
+const LEGACY_RESUME_KEYS = ['mode', 'distribution', 'profileId', 'limit'] as const
+
+function hasOwn(doc: unknown, key: string): boolean {
+  return typeof doc === 'object' && doc !== null && Object.prototype.hasOwnProperty.call(doc, key)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cleanLegacyLastOutput(lastOutput: unknown): {
+  cleaned: unknown
+  legacyRuntimeDetected: boolean
+  unknownShape: boolean
+} {
+  if (typeof lastOutput === 'undefined') {
+    return { cleaned: undefined, legacyRuntimeDetected: false, unknownShape: false }
+  }
+
+  if (lastOutput === null) {
+    return { cleaned: null, legacyRuntimeDetected: false, unknownShape: false }
+  }
+
+  if (!isRecord(lastOutput)) {
+    return { cleaned: lastOutput, legacyRuntimeDetected: false, unknownShape: true }
+  }
+
+  const next: Record<string, unknown> = { ...lastOutput }
+  let legacyRuntimeDetected = false
+
+  for (const key of LEGACY_LAST_OUTPUT_KEYS) {
+    if (hasOwn(next, key)) {
+      delete next[key]
+      legacyRuntimeDetected = true
+    }
+  }
+
+  if (hasOwn(next, 'resumeState')) {
+    const resumeState = next.resumeState
+    if (resumeState === null || typeof resumeState === 'undefined') {
+      // No-op.
+    } else if (!isRecord(resumeState)) {
+      delete next.resumeState
+      legacyRuntimeDetected = true
+    } else {
+      const resumeHasLegacyKey = LEGACY_RESUME_KEYS.some((key) => hasOwn(resumeState, key))
+      if (resumeHasLegacyKey) {
+        delete next.resumeState
+        legacyRuntimeDetected = true
+      }
+    }
+  }
+
+  return { cleaned: next, legacyRuntimeDetected, unknownShape: false }
+}
+
+export const scraperAutoOnlyApplyProfileCleanup = mutation({
+  args: {
+    profileId: v.id('profiles'),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.profileId)
+    if (!existing) {
+      return { updated: false, removedAutomation: false }
+    }
+
+    const doc = existing as Record<string, unknown>
+    const hadAutomation = hasOwn(doc, 'automation')
+    if (!hadAutomation) {
+      return { updated: false, removedAutomation: false }
+    }
+
+    await ctx.db.patch(args.profileId, {
+      automation: undefined,
+    } as any)
+
+    return { updated: true, removedAutomation: true }
+  },
+})
+
+export const scraperAutoOnlyApplyTaskCleanup = mutation({
+  args: {
+    taskId: v.id('scrapingTasks'),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.taskId)
+    if (!existing) {
+      return {
+        updated: false,
+        removedLegacyFields: 0,
+        resetToIdle: false,
+        clearedRuntimeState: false,
+        unknownLastOutputShape: false,
+      }
+    }
+
+    const doc = existing as Record<string, unknown>
+    const status = String(existing.status ?? '').toLowerCase()
+    const needsReset = status === 'running' || status === 'paused'
+    const cleanedLastOutput = cleanLegacyLastOutput(existing.lastOutput)
+
+    const patch: Record<string, unknown> = {}
+    let removedLegacyFields = 0
+
+    for (const key of ['mode', 'profileId', 'limit'] as const) {
+      if (hasOwn(doc, key)) {
+        patch[key] = undefined
+        removedLegacyFields += 1
+      }
+    }
+
+    if (needsReset) {
+      patch.status = 'idle'
+    }
+
+    if (cleanedLastOutput.legacyRuntimeDetected) {
+      patch.lastOutput = cleanedLastOutput.cleaned
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return {
+        updated: false,
+        removedLegacyFields,
+        resetToIdle: needsReset,
+        clearedRuntimeState: cleanedLastOutput.legacyRuntimeDetected,
+        unknownLastOutputShape: cleanedLastOutput.unknownShape,
+      }
+    }
+
+    patch.updatedAt = Date.now()
+    await ctx.db.patch(args.taskId, patch as any)
+
+    return {
+      updated: true,
+      removedLegacyFields,
+      resetToIdle: needsReset,
+      clearedRuntimeState: cleanedLastOutput.legacyRuntimeDetected,
+      unknownLastOutputShape: cleanedLastOutput.unknownShape,
+    }
+  },
+})
+
+export const scraperAutoOnlyRollbackProfile = mutation({
+  args: {
+    profileId: v.id('profiles'),
+    hadAutomation: v.boolean(),
+    automation: v.optional(v.union(v.boolean(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.profileId)
+    if (!existing) {
+      return { restored: false }
+    }
+
+    const patch: Record<string, unknown> = {}
+    if (args.hadAutomation) {
+      patch.automation = typeof args.automation === 'boolean' ? args.automation : undefined
+    } else {
+      patch.automation = undefined
+    }
+
+    await ctx.db.patch(args.profileId, patch as any)
+    return { restored: true }
+  },
+})
+
+export const scraperAutoOnlyRollbackTask = mutation({
+  args: {
+    taskId: v.id('scrapingTasks'),
+    snapshot: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.taskId)
+    if (!existing) {
+      return { restored: false }
+    }
+
+    const snapshot = isRecord(args.snapshot) ? args.snapshot : {}
+    const patch: Record<string, unknown> = {
+      updatedAt: Date.now(),
+    }
+
+    patch.mode = hasOwn(snapshot, 'mode') ? snapshot.mode : undefined
+    patch.profileId = hasOwn(snapshot, 'profileId') ? snapshot.profileId : undefined
+    patch.limit = hasOwn(snapshot, 'limit') ? snapshot.limit : undefined
+    patch.status = hasOwn(snapshot, 'status') ? snapshot.status : existing.status
+    patch.lastOutput = hasOwn(snapshot, 'lastOutput') ? snapshot.lastOutput : existing.lastOutput
+
+    await ctx.db.patch(args.taskId, patch as any)
+    return { restored: true }
+  },
+})

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -103,7 +103,6 @@ export const create = mutation({
 		testIp: v.optional(v.boolean()),
 		fingerprintSeed: v.optional(v.string()),
 		fingerprintOs: v.optional(v.string()),
-		automation: v.optional(v.boolean()),
 		sessionId: v.optional(v.string()),
 		dailyScrapingLimit: v.optional(v.union(v.number(), v.null())),
 	},
@@ -111,14 +110,8 @@ export const create = mutation({
 		const name = String(args.name || "").trim();
 		if (!name) throw new Error("name is required");
 		const proxy = typeof args.proxy === "string" ? args.proxy : undefined;
-		const proxyTrimmed = typeof proxy === "string" ? proxy.trim() : "";
 		const sessionIdRaw = typeof args.sessionId === "string" ? args.sessionId.trim() : "";
 		const dailyLimit = typeof args.dailyScrapingLimit === "number" ? args.dailyScrapingLimit : undefined;
-
-		// Validate: automation=false requires proxy
-		if (args.automation === false && !proxyTrimmed) {
-			throw new Error("Proxy is required when automation is disabled (for scraping)");
-		}
 
 		const id = await ctx.db.insert("profiles", {
 			createdAt: Date.now(),
@@ -127,7 +120,6 @@ export const create = mutation({
 			proxyType: args.proxyType,
 			status: "idle",
 			mode: computeProfileMode(proxy),
-			automation: args.automation ?? false,
 			sessionId: sessionIdRaw ? sessionIdRaw : undefined,
 			using: false,
 			testIp: args.testIp ?? false,
@@ -152,7 +144,6 @@ export const updateByName = mutation({
 		testIp: v.optional(v.boolean()),
 		fingerprintSeed: v.optional(v.string()),
 		fingerprintOs: v.optional(v.string()),
-		automation: v.optional(v.boolean()),
 		sessionId: v.optional(v.string()),
 		dailyScrapingLimit: v.optional(v.union(v.number(), v.null())),
 	},
@@ -168,25 +159,11 @@ export const updateByName = mutation({
 		const name = String(args.name || "").trim();
 		if (!name) throw new Error("name is required");
 
-		// Determine final values for validation BEFORE building update object
-		const finalProxy = typeof args.proxy === "string" ? args.proxy : existing.proxy;
-		const finalAutomation = typeof args.automation === "boolean" ? args.automation : existing.automation;
-
-		// Validate: automation=false requires proxy - do this FIRST before any updates
-		const proxyTrimmed = typeof finalProxy === "string" ? finalProxy.trim() : "";
-		if (finalAutomation === false && !proxyTrimmed) {
-			throw new Error("Proxy is required when automation is disabled (for scraping)");
-		}
-
-		// Now build the update object after validation passed
 		const next: Record<string, unknown> = { name };
 
 		if (typeof args.proxy === "string") {
 			next.proxy = args.proxy;
 			next.mode = computeProfileMode(args.proxy);
-		}
-		if (typeof args.automation === "boolean") {
-			next.automation = args.automation;
 		}
 		if (typeof args.proxyType === "string") {
 			next.proxyType = args.proxyType;
@@ -225,7 +202,6 @@ export const updateById = mutation({
 		testIp: v.optional(v.boolean()),
 		fingerprintSeed: v.optional(v.string()),
 		fingerprintOs: v.optional(v.string()),
-		automation: v.optional(v.boolean()),
 		sessionId: v.optional(v.string()),
 		dailyScrapingLimit: v.optional(v.union(v.number(), v.null())),
 	},
@@ -235,25 +211,11 @@ export const updateById = mutation({
 		const existing = await ctx.db.get(args.profileId);
 		if (!existing) throw new Error("Profile not found");
 
-		// Determine final values for validation BEFORE building update object
-		const finalProxy = typeof args.proxy === "string" ? args.proxy : existing.proxy;
-		const finalAutomation = typeof args.automation === "boolean" ? args.automation : existing.automation;
-
-		// Validate: automation=false requires proxy - do this FIRST before any updates
-		const proxyTrimmed = typeof finalProxy === "string" ? finalProxy.trim() : "";
-		if (finalAutomation === false && !proxyTrimmed) {
-			throw new Error("Proxy is required when automation is disabled (for scraping)");
-		}
-
-		// Now build the update object after validation passed
 		const next: Record<string, unknown> = { name };
 
 		if (typeof args.proxy === "string") {
 			next.proxy = args.proxy;
 			next.mode = computeProfileMode(args.proxy);
-		}
-		if (typeof args.automation === "boolean") {
-			next.automation = args.automation;
 		}
 		if (typeof args.proxyType === "string") {
 			next.proxyType = args.proxyType;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,7 +14,6 @@ export default defineSchema({
 		proxyType: v.optional(v.string()),
 		status: v.optional(v.string()),
 		mode: v.optional(v.string()),
-		automation: v.optional(v.boolean()),
 		sessionId: v.optional(v.string()),
 		using: v.boolean(),
 		testIp: v.boolean(),
@@ -54,10 +53,7 @@ export default defineSchema({
 	scrapingTasks: defineTable({
 		name: v.string(),
 		kind: v.string(),
-		mode: v.string(),
-		profileId: v.optional(v.string()),
 		targetUsername: v.string(),
-		limit: v.number(),
 		imported: v.optional(v.boolean()),
 		status: v.optional(v.string()),
 		lastRunAt: v.optional(v.number()),

--- a/convex/scrapingTasks.ts
+++ b/convex/scrapingTasks.ts
@@ -6,16 +6,6 @@ function cleanString(val: unknown): string {
 	return String(val ?? "").trim();
 }
 
-function clampLimit(val: unknown): number {
-	const lim = Number.isFinite(Number(val)) ? Math.floor(Number(val)) : 200;
-	return Math.max(1, Math.min(5000, lim));
-}
-
-function cleanMode(val: unknown): "auto" | "manual" {
-	const s = cleanString(val).toLowerCase();
-	return s === "manual" ? "manual" : "auto";
-}
-
 function cleanStatus(val: unknown): "idle" | "running" | "paused" | "completed" | "failed" {
 	const s = cleanString(val).toLowerCase();
 	if (s === "running" || s === "paused" || s === "completed" || s === "failed") return s;
@@ -48,10 +38,7 @@ export const create = mutation({
 	args: {
 		name: v.string(),
 		kind: v.optional(v.string()),
-		mode: v.optional(v.string()),
-		profileId: v.optional(v.string()),
 		targetUsername: v.string(),
-		limit: v.optional(v.number()),
 	},
 	handler: async (ctx, args) => {
 		const name = cleanString(args.name);
@@ -61,21 +48,12 @@ export const create = mutation({
 		if (!targetUsername) throw new Error("targetUsername is required");
 
 		const kind = cleanString(args.kind) || "followers";
-		const mode = cleanMode(args.mode);
-		const profileId = cleanString(args.profileId);
-
-		if (mode === "manual" && !profileId) {
-			throw new Error("profileId is required for manual mode");
-		}
 
 		const now = Date.now();
 		const id = await ctx.db.insert("scrapingTasks", {
 			name,
 			kind,
-			mode,
-			profileId: mode === "manual" ? profileId : undefined,
 			targetUsername,
-			limit: clampLimit(args.limit),
 			imported: false,
 			status: "idle",
 			createdAt: now,
@@ -118,20 +96,11 @@ export const update = mutation({
 		id: v.id("scrapingTasks"),
 		name: v.optional(v.string()),
 		kind: v.optional(v.string()),
-		mode: v.optional(v.string()),
-		profileId: v.optional(v.string()),
 		targetUsername: v.optional(v.string()),
-		limit: v.optional(v.number()),
 	},
 	handler: async (ctx, args) => {
 		const existing = await ctx.db.get(args.id);
 		if (!existing) throw new Error("Task not found");
-
-		const nextMode = args.mode !== undefined ? cleanMode(args.mode) : (existing.mode as "auto" | "manual");
-		const nextProfileId = args.profileId !== undefined ? cleanString(args.profileId) : (existing.profileId ?? "");
-		if (nextMode === "manual" && !nextProfileId) {
-			throw new Error("profileId is required for manual mode");
-		}
 
 		const patch: Record<string, unknown> = { updatedAt: Date.now() };
 		if (args.name !== undefined) patch.name = cleanString(args.name) || existing.name;
@@ -141,9 +110,6 @@ export const update = mutation({
 			if (!cleaned) throw new Error("targetUsername is required");
 			patch.targetUsername = cleaned;
 		}
-		if (args.mode !== undefined) patch.mode = nextMode;
-		if (args.profileId !== undefined) patch.profileId = nextMode === "manual" ? nextProfileId : undefined;
-		if (args.limit !== undefined) patch.limit = clampLimit(args.limit);
 
 		await ctx.db.patch(args.id, patch);
 		return await ctx.db.get(args.id);

--- a/frontend/src/tabs/accounts/types.ts
+++ b/frontend/src/tabs/accounts/types.ts
@@ -42,9 +42,7 @@ export interface ScrapingTaskRow {
     _id: string
     name: string
     kind: string
-    mode?: string
     targetUsername?: string
-    limit?: number
     status?: string
     storageId?: string
     imported?: boolean

--- a/frontend/src/tabs/profiles/ProfileDetails.tsx
+++ b/frontend/src/tabs/profiles/ProfileDetails.tsx
@@ -102,7 +102,7 @@ export function ProfileDetails({
                     <Box className="h-4 w-4" /> Metadata
                 </h4>
                 <p className="text-xs text-muted-foreground leading-relaxed">
-                    This profile is managed by the automation system. Be careful when modifying fingerprint settings as it may trigger re-authentication verification on target platforms.
+                    This profile can be used for manual browser sessions and, when it has a proxy and session, contribute scraping capacity. Be careful when modifying fingerprint settings as it may trigger re-authentication verification on target platforms.
                 </p>
             </div>
         </div>

--- a/frontend/src/tabs/profiles/ProfileForm.tsx
+++ b/frontend/src/tabs/profiles/ProfileForm.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { Profile } from './types'
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -42,7 +41,6 @@ export function ProfileForm({
   const [draft, setDraft] = useState<Partial<Profile>>({
     name: '',
     test_ip: false,
-    automation: false,
     login: false,
     using: false,
     status: 'idle',
@@ -103,13 +101,6 @@ export function ProfileForm({
     } else if (connection === 'direct') {
       finalData.proxy = '';
       finalData.proxy_type = '';
-    }
-
-    // Validate: automation=false requires proxy
-    const hasProxy = connection === 'proxy' && finalData.proxy && finalData.proxy.trim()
-    if (finalData.automation === false && !hasProxy) {
-      setLocalError('Proxy is required when automation is disabled (for scraping)')
-      return
     }
 
     setLocalError(null)
@@ -245,67 +236,49 @@ export function ProfileForm({
 
           <Separator />
 
-          <div className="flex items-center justify-between py-2">
-            <Label htmlFor="automation" className="cursor-pointer flex flex-col gap-0.5">
-              <span className="font-medium">Automation Mode</span>
-              <span className="text-xs text-muted-foreground font-normal">Enable additional scraping protections</span>
-            </Label>
-            <Checkbox
-              id="automation"
-              checked={Boolean(draft.automation)}
-              onCheckedChange={(checked) => setDraft((prev) => ({ ...prev, automation: Boolean(checked) }))}
-              disabled={saving}
-            />
-          </div>
-
-          {draft.automation === false && (
-            <div className="animate-in fade-in slide-in-from-top-1 duration-200">
-              <Separator className="mb-4" />
-              <div className="grid gap-4">
-                <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium flex items-center gap-2">
-                    <Target className="h-4 w-4" /> Daily Scraping Limit
-                  </Label>
-                </div>
-                <div className="p-4 border rounded-md bg-card space-y-3">
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="daily_scraping_limit" className="text-xs text-muted-foreground">
-                      Maximum items to scrape per day
-                    </Label>
-                    <Input
-                      id="daily_scraping_limit"
-                      type="number"
-                      min="0"
-                      step="1"
-                      value={draft.daily_scraping_limit ?? ''}
-                      onChange={(e) => {
-                        const val = e.target.value.trim()
-                        setDraft((prev) => ({
-                          ...prev,
-                          daily_scraping_limit: val === '' ? null : Math.max(0, Math.floor(Number(val)))
-                        }))
-                      }}
-                      disabled={saving}
-                      placeholder="Leave empty for unlimited"
-                      className="h-9"
-                    />
-                    <p className="text-[10px] text-muted-foreground ml-1">
-                      Set a daily limit to prevent overuse. Leave empty for no limit.
-                    </p>
-                  </div>
-                  {typeof draft.daily_scraping_used === 'number' && draft.daily_scraping_used > 0 && (
-                    <div className="text-xs bg-muted/50 p-2 rounded border border-border/50">
-                      <span className="text-muted-foreground">Used today: </span>
-                      <span className="font-semibold">{draft.daily_scraping_used}</span>
-                      {typeof draft.daily_scraping_limit === 'number' && (
-                        <span className="text-muted-foreground"> / {draft.daily_scraping_limit}</span>
-                      )}
-                    </div>
+          <div className="grid gap-4">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium flex items-center gap-2">
+                <Target className="h-4 w-4" /> Daily Scraping Limit
+              </Label>
+            </div>
+            <div className="p-4 border rounded-md bg-card space-y-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="daily_scraping_limit" className="text-xs text-muted-foreground">
+                  Maximum items to scrape per day
+                </Label>
+                <Input
+                  id="daily_scraping_limit"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={draft.daily_scraping_limit ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value.trim()
+                    setDraft((prev) => ({
+                      ...prev,
+                      daily_scraping_limit: val === '' ? null : Math.max(0, Math.floor(Number(val)))
+                    }))
+                  }}
+                  disabled={saving}
+                  placeholder="Leave empty for unlimited"
+                  className="h-9"
+                />
+                <p className="text-[10px] text-muted-foreground ml-1">
+                  Controls how much scraping capacity this profile can contribute each day. Leave empty for no limit.
+                </p>
+              </div>
+              {typeof draft.daily_scraping_used === 'number' && draft.daily_scraping_used > 0 && (
+                <div className="text-xs bg-muted/50 p-2 rounded border border-border/50">
+                  <span className="text-muted-foreground">Used today: </span>
+                  <span className="font-semibold">{draft.daily_scraping_used}</span>
+                  {typeof draft.daily_scraping_limit === 'number' && (
+                    <span className="text-muted-foreground"> / {draft.daily_scraping_limit}</span>
                   )}
                 </div>
-              </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
       </ScrollArea>
 

--- a/frontend/src/tabs/profiles/ProfilesPage.tsx
+++ b/frontend/src/tabs/profiles/ProfilesPage.tsx
@@ -161,7 +161,6 @@ export function ProfilesPage() {
             fingerprint_seed: data.fingerprint_seed || undefined,
             fingerprint_os: data.fingerprint_os || undefined,
             test_ip: Boolean(data.test_ip),
-            automation: Boolean(data.automation),
             daily_scraping_limit: typeof data.daily_scraping_limit === 'number' ? data.daily_scraping_limit : null,
           },
         })
@@ -177,7 +176,6 @@ export function ProfilesPage() {
             fingerprint_seed: data.fingerprint_seed || undefined,
             fingerprint_os: data.fingerprint_os || undefined,
             test_ip: Boolean(data.test_ip),
-            automation: Boolean(data.automation),
             daily_scraping_limit: typeof data.daily_scraping_limit === 'number' ? data.daily_scraping_limit : null,
           },
         })
@@ -235,7 +233,7 @@ export function ProfilesPage() {
       <div className="flex items-center justify-between px-6 py-4 border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
         <div>
           <h2 className="text-xl font-semibold tracking-tight">Profiles</h2>
-          <p className="text-sm text-muted-foreground">Manage your browser automation instances.</p>
+          <p className="text-sm text-muted-foreground">Manage your browser profiles, proxies, and scraping capacity.</p>
         </div>
         <div className="flex items-center gap-3">
           <Button

--- a/frontend/src/tabs/profiles/types.ts
+++ b/frontend/src/tabs/profiles/types.ts
@@ -5,7 +5,6 @@ export type Profile = {
   proxy_type?: string
   fingerprint_seed?: string
   fingerprint_os?: string
-  automation?: boolean
   test_ip?: boolean
   status?: string
   using?: boolean

--- a/frontend/src/tabs/scraping/ScrapingPage.tsx
+++ b/frontend/src/tabs/scraping/ScrapingPage.tsx
@@ -12,11 +12,6 @@ import { DeleteTaskDialog } from './DeleteTaskDialog'
 
 type EligibleProfile = { id: string; name: string }
 
-function clampLimit(limit: string | number): number {
-  const lim = Number.isFinite(Number(limit)) ? Math.floor(Number(limit)) : 200
-  return Math.max(1, Math.min(5000, lim))
-}
-
 function parseTargets(raw: string): string[] {
   const text = String(raw || '')
   if (!text.trim()) return []
@@ -38,10 +33,7 @@ function parseTargets(raw: string): string[] {
 
 export function ScrapingPage() {
   const [kind, setKind] = useState<'followers' | 'following'>('followers')
-  const [autoMode, setAutoMode] = useState(false)
-  const [selectedProfileId, setSelectedProfileId] = useState<string>('')
   const [targetUsername, setTargetUsername] = useState('')
-  const [limit, setLimit] = useState('200')
   const [taskName, setTaskName] = useState('')
 
   const [error, setError] = useState<string | null>(null)
@@ -76,15 +68,6 @@ export function ScrapingPage() {
     void refreshEligibleProfiles()
   }, [refreshEligibleProfiles])
 
-  const eligibleSet = useMemo(() => new Set(eligibleProfiles.map((p) => p.id)), [eligibleProfiles])
-
-  useEffect(() => {
-    if (autoMode) return
-    if (!selectedProfileId) return
-    if (eligibleSet.size === 0) return
-    if (!eligibleSet.has(selectedProfileId)) setSelectedProfileId('')
-  }, [autoMode, eligibleSet, selectedProfileId])
-
   const tasks = useQuery(api.scrapingTasks.list, {}) as Doc<'scrapingTasks'>[] | undefined
   const createTaskMutation = useMutation(api.scrapingTasks.create)
   const updateTaskMutation = useMutation(api.scrapingTasks.update)
@@ -96,16 +79,11 @@ export function ScrapingPage() {
 
   const canCreate = useMemo(() => {
     if (parseTargets(targetUsername).length === 0) return false
-    if (!autoMode && !selectedProfileId) return false
-    if (!autoMode && selectedProfileId && !eligibleSet.has(selectedProfileId)) return false
     return true
-  }, [autoMode, eligibleSet, selectedProfileId, targetUsername])
+  }, [targetUsername])
 
   const [editKind, setEditKind] = useState<'followers' | 'following'>('followers')
-  const [editAutoMode, setEditAutoMode] = useState(false)
-  const [editSelectedProfileId, setEditSelectedProfileId] = useState<string>('')
   const [editTargetUsername, setEditTargetUsername] = useState('')
-  const [editLimit, setEditLimit] = useState('200')
   const [editTaskName, setEditTaskName] = useState('')
 
   const handleOpenCreate = useCallback(() => {
@@ -128,12 +106,8 @@ export function ScrapingPage() {
       setError(null)
 
       const taskKind = task.kind === 'following' ? 'following' : 'followers'
-      const mode = task.mode === 'manual' ? 'manual' : 'auto'
       setEditKind(taskKind)
-      setEditAutoMode(mode === 'auto')
-      setEditSelectedProfileId(typeof task.profileId === 'string' ? task.profileId : '')
       setEditTargetUsername(String(task.targetUsername || ''))
-      setEditLimit(String(task.limit ?? 200))
       setEditTaskName(String(task.name || ''))
     },
     []
@@ -148,10 +122,8 @@ export function ScrapingPage() {
     if (!isEditOpen) return false
     if (!editTaskName.trim()) return false
     if (parseTargets(editTargetUsername).length === 0) return false
-    if (!editAutoMode && !editSelectedProfileId) return false
-    if (!editAutoMode && editSelectedProfileId && !eligibleSet.has(editSelectedProfileId)) return false
     return true
-  }, [editAutoMode, editSelectedProfileId, editTargetUsername, editTaskName, eligibleSet, isEditOpen])
+  }, [editTargetUsername, editTaskName, isEditOpen])
 
   const handleCreateTask = useCallback(async () => {
     if (!canCreate) return
@@ -160,7 +132,6 @@ export function ScrapingPage() {
     if (!firstTarget) return
     const packedTargets = targets.join('\n')
 
-    const effectiveLimit = clampLimit(limit)
     const baseName = String(taskName || '').trim()
 
     try {
@@ -168,31 +139,21 @@ export function ScrapingPage() {
       const created = await createTaskMutation({
         name,
         kind,
-        mode: autoMode ? 'auto' : 'manual',
-        ...(autoMode ? {} : { profileId: selectedProfileId }),
         targetUsername: packedTargets,
-        limit: effectiveLimit,
       })
       setIsCreateOpen(false)
       if (created?._id) setSelectedId(created._id)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     }
-  }, [autoMode, canCreate, createTaskMutation, kind, limit, selectedProfileId, taskName, targetUsername])
+  }, [canCreate, createTaskMutation, kind, taskName, targetUsername])
 
   const handleRunTask = useCallback(
     async (task: Doc<'scrapingTasks'>, opts?: { resume?: boolean }) => {
       if (runningId) return
 
-      const taskMode = task.mode === 'manual' ? 'manual' : 'auto'
       const taskTargets = parseTargets(String(task.targetUsername || ''))
       if (taskTargets.length === 0) return
-
-      const taskProfileId = typeof task.profileId === 'string' ? task.profileId : ''
-      if (taskMode === 'manual' && (!taskProfileId || !eligibleSet.has(taskProfileId))) {
-        setError('Selected profile is not eligible.')
-        return
-      }
 
       setRunningId(task._id)
       setError(null)
@@ -221,6 +182,7 @@ export function ScrapingPage() {
         let lastStorageId: unknown = task.storageId
         let resumeState: unknown = resume ? existingResumeState : undefined
         let done = false
+        let capacityExhaustedMessage: string | undefined
         let chunkLimit = 100
         let maxPages = 3
 
@@ -242,6 +204,15 @@ export function ScrapingPage() {
           return r.storageId
         }
 
+        const getCapacityExhaustedMessage = (res: unknown): string | undefined => {
+          if (!res || typeof res !== 'object') return undefined
+          const r = res as Record<string, unknown>
+          if (r.capacityExhausted !== true) return undefined
+          return typeof r.error === 'string' && r.error.trim()
+            ? r.error
+            : 'Daily scraping capacity exhausted before all targets were completed'
+        }
+
         const maxIterations = 50
         for (let i = 0; i < maxIterations; i++) {
           if (Date.now() - startedAt > 110000) break
@@ -251,9 +222,7 @@ export function ScrapingPage() {
             output = await apiFetchWithRetry<unknown>(apiEndpoint, {
               method: 'POST',
               body: {
-                ...(taskMode === 'auto' ? { distribution: 'auto' } : { profileId: taskProfileId }),
                 targetUsernames: taskTargets,
-                limit: clampLimit(task.limit),
                 taskId: task._id,
                 resume: resume || i > 0,
                 ...((resume || i > 0) ? { resumeState, storageId: lastStorageId } : {}),
@@ -273,9 +242,7 @@ export function ScrapingPage() {
               output = await apiFetchWithRetry<unknown>(apiEndpoint, {
                 method: 'POST',
                 body: {
-                  ...(taskMode === 'auto' ? { distribution: 'auto' } : { profileId: taskProfileId }),
                   targetUsernames: taskTargets,
-                  limit: clampLimit(task.limit),
                   taskId: task._id,
                   resume: resume || i > 0,
                   ...((resume || i > 0) ? { resumeState, storageId: lastStorageId } : {}),
@@ -296,17 +263,18 @@ export function ScrapingPage() {
           if (sid !== undefined) lastStorageId = sid
 
           done = getDone(output)
+          capacityExhaustedMessage = getCapacityExhaustedMessage(output)
 
           await setTaskStatusMutation({
             id: task._id,
             status: done ? 'completed' : 'running',
             lastRunAt: startAt,
             lastScraped: undefined,
-            lastError: undefined,
+            lastError: capacityExhaustedMessage,
             lastOutput,
           })
 
-          if (done) break
+          if (done || capacityExhaustedMessage) break
           await new Promise((r) => setTimeout(r, 250))
         }
 
@@ -323,7 +291,7 @@ export function ScrapingPage() {
           status: done ? 'completed' : 'paused',
           lastRunAt: startAt,
           lastScraped,
-          lastError: undefined,
+          lastError: capacityExhaustedMessage,
           lastOutput: lastOutput ?? undefined,
         })
       } catch (e) {
@@ -340,7 +308,7 @@ export function ScrapingPage() {
         setRunningId(null)
       }
     },
-    [eligibleSet, runningId, setTaskStatusMutation]
+    [runningId, setTaskStatusMutation]
   )
 
   const handleViewOutput = useCallback(
@@ -379,23 +347,19 @@ export function ScrapingPage() {
     const cleanedTargets = parseTargets(editTargetUsername)
     const packedTargets = cleanedTargets.join('\n')
     if (!packedTargets) return
-    const safeLimit = clampLimit(editLimit)
 
     try {
       await updateTaskMutation({
         id: selectedId,
         name: cleanedName,
         kind: editKind,
-        mode: editAutoMode ? 'auto' : 'manual',
-        ...(editAutoMode ? {} : { profileId: editSelectedProfileId }),
         targetUsername: packedTargets,
-        limit: safeLimit,
       })
       setIsEditOpen(false)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     }
-  }, [canSaveEdit, editAutoMode, editKind, editLimit, editSelectedProfileId, editTargetUsername, editTaskName, selectedId, updateTaskMutation])
+  }, [canSaveEdit, editKind, editTargetUsername, editTaskName, selectedId, updateTaskMutation])
 
   return (
     <div className="flex flex-col h-full bg-background">
@@ -434,7 +398,6 @@ export function ScrapingPage() {
             tasks={tasksList}
             selectedId={selectedId}
             onSelect={setSelectedId}
-            eligibleProfiles={eligibleProfiles}
             running={Boolean(runningId)}
             onRun={(task) => void handleRunTask(task, { resume: false })}
             onResume={(task) => void handleRunTask(task, { resume: true })}
@@ -460,16 +423,9 @@ export function ScrapingPage() {
         onTaskNameChange={setTaskName}
         kind={kind}
         onKindChange={setKind}
-        autoMode={autoMode}
-        onAutoModeChange={setAutoMode}
-        selectedProfileId={selectedProfileId}
-        onSelectedProfileIdChange={setSelectedProfileId}
         targetUsername={targetUsername}
         onTargetUsernameChange={setTargetUsername}
-        limit={limit}
-        onLimitChange={setLimit}
         eligibleProfiles={eligibleProfiles}
-        eligibleSet={eligibleSet}
         eligibleLoading={eligibleLoading}
         submitLabel="Create"
         submitDisabled={!canCreate}
@@ -490,16 +446,9 @@ export function ScrapingPage() {
         onTaskNameChange={setEditTaskName}
         kind={editKind}
         onKindChange={setEditKind}
-        autoMode={editAutoMode}
-        onAutoModeChange={setEditAutoMode}
-        selectedProfileId={editSelectedProfileId}
-        onSelectedProfileIdChange={setEditSelectedProfileId}
         targetUsername={editTargetUsername}
         onTargetUsernameChange={setEditTargetUsername}
-        limit={editLimit}
-        onLimitChange={setEditLimit}
         eligibleProfiles={eligibleProfiles}
-        eligibleSet={eligibleSet}
         eligibleLoading={eligibleLoading}
         submitLabel="Save"
         submitDisabled={!canSaveEdit}

--- a/frontend/src/tabs/scraping/TaskDialog.tsx
+++ b/frontend/src/tabs/scraping/TaskDialog.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -17,16 +16,9 @@ type Props = {
   onTaskNameChange: (next: string) => void
   kind: 'followers' | 'following'
   onKindChange: (next: 'followers' | 'following') => void
-  autoMode: boolean
-  onAutoModeChange: (next: boolean) => void
-  selectedProfileId: string
-  onSelectedProfileIdChange: (next: string) => void
   targetUsername: string
   onTargetUsernameChange: (next: string) => void
-  limit: string
-  onLimitChange: (next: string) => void
   eligibleProfiles: EligibleProfile[]
-  eligibleSet: Set<string>
   eligibleLoading: boolean
   submitLabel: string
   submitDisabled: boolean
@@ -44,16 +36,9 @@ export function TaskDialog({
   onTaskNameChange,
   kind,
   onKindChange,
-  autoMode,
-  onAutoModeChange,
-  selectedProfileId,
-  onSelectedProfileIdChange,
   targetUsername,
   onTargetUsernameChange,
-  limit,
-  onLimitChange,
   eligibleProfiles,
-  eligibleSet,
   eligibleLoading,
   submitLabel,
   submitDisabled,
@@ -92,40 +77,12 @@ export function TaskDialog({
             </Select>
           </div>
 
-          <div className="rounded-md border bg-background p-3 flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-sm font-medium">Auto distribution</div>
-              <div className="text-xs text-muted-foreground mt-1">Split work across all eligible profiles.</div>
-            </div>
-            <Checkbox checked={autoMode} onCheckedChange={(v) => onAutoModeChange(Boolean(v))} />
-          </div>
-
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label>Profile</Label>
-              <Select value={selectedProfileId} onValueChange={onSelectedProfileIdChange} disabled={autoMode}>
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={
-                      autoMode
-                        ? 'Auto distribution enabled'
-                        : eligibleLoading
-                          ? 'Loading eligible profiles...'
-                          : 'Select a profile'
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {eligibleProfiles.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {!autoMode && selectedProfileId && !eligibleSet.has(selectedProfileId) && (
-                <div className="text-xs text-destructive">Selected profile is not eligible.</div>
-              )}
+              <Label>Assignment</Label>
+              <div className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+                Tasks are distributed automatically across eligible profiles.
+              </div>
             </div>
 
             <div className="space-y-2">
@@ -145,22 +102,6 @@ export function TaskDialog({
                 className="min-h-[140px]"
               />
               <div className="text-xs text-muted-foreground">One username per line. Task runs each one.</div>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor={`${idPrefix}_limit`}>Total Limit</Label>
-            <Input
-              id={`${idPrefix}_limit`}
-              inputMode="numeric"
-              placeholder="200"
-              value={limit}
-              onChange={(e) => onLimitChange(e.target.value)}
-            />
-            <div className="text-xs text-muted-foreground">
-              {autoMode 
-                ? 'Work will be distributed across profiles based on their daily limits.'
-                : 'Maximum items to scrape for the selected profile.'}
             </div>
           </div>
 

--- a/frontend/src/tabs/scraping/TasksTable.tsx
+++ b/frontend/src/tabs/scraping/TasksTable.tsx
@@ -19,8 +19,6 @@ import {
 import { Download, Eye, MoreHorizontal, Pencil, Play, Trash2 } from 'lucide-react'
 import type { Doc, Id } from '../../../../convex/_generated/dataModel'
 
-type EligibleProfile = { id: string; name: string }
-
 function parseTargets(raw: string): string[] {
   const text = String(raw || '')
   if (!text.trim()) return []
@@ -49,7 +47,6 @@ type Props = {
   tasks: Doc<'scrapingTasks'>[]
   selectedId: Id<'scrapingTasks'> | null
   onSelect: (id: Id<'scrapingTasks'>) => void
-  eligibleProfiles: EligibleProfile[]
   running: boolean
   onRun: (task: Doc<'scrapingTasks'>) => void
   onResume: (task: Doc<'scrapingTasks'>) => void
@@ -62,7 +59,6 @@ export function TasksTable({
   tasks,
   selectedId,
   onSelect,
-  eligibleProfiles,
   running,
   onRun,
   onResume,
@@ -102,8 +98,6 @@ export function TasksTable({
             <TableHead>Name</TableHead>
             <TableHead>Type</TableHead>
             <TableHead>Target</TableHead>
-            <TableHead>Mode</TableHead>
-            <TableHead>Limit</TableHead>
             <TableHead>Last run</TableHead>
             <TableHead>Status</TableHead>
             <TableHead className="text-right">Actions</TableHead>
@@ -111,11 +105,6 @@ export function TasksTable({
         </TableHeader>
         <TableBody>
           {tasks.map((task) => {
-            const taskMode = task.mode === 'manual' ? 'manual' : 'auto'
-            const profileName =
-              taskMode === 'manual'
-                ? eligibleProfiles.find((p) => p.id === task.profileId)?.name || task.profileId || '—'
-                : 'Auto distribution'
             const taskStatus =
               task.status === 'running' || task.status === 'paused' || task.status === 'completed' || task.status === 'failed' ? task.status : 'idle'
             const statusBadge =
@@ -169,17 +158,6 @@ export function TasksTable({
                       </span>
                     )
                   })()}
-                </TableCell>
-                <TableCell>
-                  <div className="flex flex-col">
-                    <div className="flex items-center gap-2">
-                      <Badge variant={taskMode === 'auto' ? 'outline' : 'secondary'}>{taskMode === 'auto' ? 'Auto' : 'Manual'}</Badge>
-                    </div>
-                    <span className="text-xs text-muted-foreground truncate max-w-[220px]">{profileName}</span>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <span>{task.limit}</span>
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">{formatWhen(task.lastRunAt)}</TableCell>
                 <TableCell>

--- a/scraper/api.py
+++ b/scraper/api.py
@@ -70,7 +70,6 @@ class FollowersScrapeRequest(BaseModel):
     auth_username: str = Field(min_length=1)
     session_id: str = Field(min_length=1)
     target_username: str = Field(min_length=1)
-    limit: int = Field(default=200, ge=1, le=5000)
     cursor: Optional[str] = None
     chunk_limit: int = Field(default=200, ge=1, le=5000)
     max_pages: int = Field(default=10, ge=1, le=100)
@@ -81,7 +80,6 @@ class FollowingScrapeRequest(BaseModel):
     auth_username: str = Field(min_length=1)
     session_id: str = Field(min_length=1)
     target_username: str = Field(min_length=1)
-    limit: int = Field(default=200, ge=1, le=5000)
     cursor: Optional[str] = None
     chunk_limit: int = Field(default=200, ge=1, le=5000)
     max_pages: int = Field(default=10, ge=1, le=100)
@@ -110,14 +108,12 @@ async def scrape_followers(req: FollowersScrapeRequest):
     if not user_id:
         raise HTTPException(status_code=404, detail="Failed to resolve target user id")
 
-    overall_limit = int(req.limit)
-    chunk_limit = min(int(req.chunk_limit), overall_limit)
     users, next_cursor, has_more = Get_Followers.get_data_chunk(
         user_id=user_id,
         username=target_username,
         session_id=session_id,
         cursor=cursor,
-        chunk_limit=chunk_limit,
+        chunk_limit=int(req.chunk_limit),
         max_pages=int(req.max_pages),
         proxy=proxy,
     )
@@ -125,8 +121,7 @@ async def scrape_followers(req: FollowersScrapeRequest):
     return {
         "targetUsername": target_username,
         "scraped": len(users or []),
-        "limit": overall_limit,
-        "chunkLimit": chunk_limit,
+        "chunkLimit": int(req.chunk_limit),
         "cursor": cursor,
         "nextCursor": next_cursor,
         "hasMore": bool(has_more),
@@ -152,14 +147,12 @@ async def scrape_following(req: FollowingScrapeRequest):
     if not user_id:
         raise HTTPException(status_code=404, detail="Failed to resolve target user id")
 
-    overall_limit = int(req.limit)
-    chunk_limit = min(int(req.chunk_limit), overall_limit)
     users, next_cursor, has_more = Get_Following.get_data_chunk(
         user_id=user_id,
         username=target_username,
         session_id=session_id,
         cursor=cursor,
-        chunk_limit=chunk_limit,
+        chunk_limit=int(req.chunk_limit),
         max_pages=int(req.max_pages),
         proxy=proxy,
     )
@@ -167,8 +160,7 @@ async def scrape_following(req: FollowingScrapeRequest):
     return {
         "targetUsername": target_username,
         "scraped": len(users or []),
-        "limit": overall_limit,
-        "chunkLimit": chunk_limit,
+        "chunkLimit": int(req.chunk_limit),
         "cursor": cursor,
         "nextCursor": next_cursor,
         "hasMore": bool(has_more),

--- a/server/api/profiles.ts
+++ b/server/api/profiles.ts
@@ -188,7 +188,6 @@ router.post('/:name/start', async (req, res) => {
                     fingerprint_seed: newSeed,
                     fingerprint_os: defaultOs,
                     test_ip: profile.test_ip,
-                    automation: profile.automation,
                     daily_scraping_limit: profile.daily_scraping_limit,
                 })
                 profile.fingerprint_seed = newSeed

--- a/server/api/scraping/chunk-core.ts
+++ b/server/api/scraping/chunk-core.ts
@@ -1,27 +1,26 @@
-// Core chunked scraping logic shared between followers-chunk and following-chunk
+// Core chunked scraping logic shared between followers-chunk and following-chunk.
 
 import { profilesIncrementDailyScrapingUsed } from '../../data/convex.js'
-import { ResumeState, HttpError } from './types.js'
+import { HttpError } from './types.js'
 import {
+  CAPACITY_EXHAUSTED_ERROR,
   SCRAPER_URL,
   cleanTargets,
-  parseLimit,
-  normalizeResume,
-  pickProfile,
-  loadExistingUsers,
   dedupeUsers,
-  storeScrapedDataIfNeeded,
+  getChunkLimitForProfile,
   handleError,
+  loadExistingUsers,
+  normalizeResume,
+  parseLimit,
+  pickProfile,
+  storeScrapedDataIfNeeded,
 } from './helpers.js'
 
 export type ChunkKind = 'followers' | 'following'
 
 interface ChunkRequestBody {
-  profileId?: string
   targetUsername?: string
   targetUsernames?: string | string[]
-  limit?: number
-  distribution?: string
   taskId?: string
   resume?: boolean
   resumeState?: unknown
@@ -63,7 +62,6 @@ async function fetchScrapeChunk(params: {
   authUsername: string
   sessionId: string
   targetUsername: string
-  limit: number
   chunkLimit: number
   maxPages: number
   cursor: string | null
@@ -76,7 +74,6 @@ async function fetchScrapeChunk(params: {
       auth_username: params.authUsername,
       session_id: params.sessionId,
       target_username: params.targetUsername,
-      limit: params.limit,
       chunk_limit: params.chunkLimit,
       max_pages: params.maxPages,
       cursor: params.cursor,
@@ -89,6 +86,10 @@ async function fetchScrapeChunk(params: {
   return { resp, text, payload }
 }
 
+function hasResumeProgress(resumeState: ReturnType<typeof normalizeResume>): boolean {
+  return resumeState.perTarget.some((target) => target.scrapedTotal > 0 || target.done || Boolean(target.cursor))
+}
+
 export async function handleChunkRequest(
   kind: ChunkKind,
   body: ChunkRequestBody,
@@ -96,11 +97,8 @@ export async function handleChunkRequest(
 ) {
   try {
     const {
-      profileId,
       targetUsername,
       targetUsernames,
-      limit,
-      distribution,
       taskId,
       resume,
       resumeState,
@@ -114,24 +112,18 @@ export async function handleChunkRequest(
       return res.status(400).json({ error: 'targetUsername is required' })
     }
 
-    const safeLimit = parseLimit(limit, 200, 1, 5000)
     const safeChunkLimit = parseLimit(chunkLimit, 200, 1, 5000)
     const safeMaxPages = parseLimit(maxPages, 10, 1, 100)
-
-    const dist = String(distribution || '').trim().toLowerCase()
     const isResume = Boolean(resume)
-    const cleanedProfileId = String(profileId || '').trim()
 
-    const resumeObj = normalizeResume(resumeState, targets, safeLimit, kind, isResume)
-    const next = resumeObj.perTarget.find((t) => !t.done) || null
-    
-    // All targets done
+    const resumeObj = normalizeResume(resumeState, targets, kind, isResume)
+    const next = resumeObj.perTarget.find((target) => !target.done) || null
+
     if (!next) {
       resumeObj.done = true
       resumeObj.updatedAt = Date.now()
       return res.json({
         kind,
-        limit: safeLimit,
         targets,
         done: true,
         resumeState: resumeObj,
@@ -139,34 +131,37 @@ export async function handleChunkRequest(
       })
     }
 
-    const remaining = Math.max(0, safeLimit - next.scrapedTotal)
-    if (remaining <= 0) {
-      next.done = true
-      next.cursor = null
-      resumeObj.done = resumeObj.perTarget.every((p) => p.done)
-      resumeObj.updatedAt = Date.now()
-      return res.json({
-        kind,
-        limit: safeLimit,
-        targets,
-        done: resumeObj.done,
-        resumeState: resumeObj,
-        ...(storageId ? { storageId } : {}),
-      })
+    let profileSelection: Awaited<ReturnType<typeof pickProfile>>
+    try {
+      profileSelection = await pickProfile(isResume || hasResumeProgress(resumeObj))
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 429 && error.message === CAPACITY_EXHAUSTED_ERROR) {
+        resumeObj.done = false
+        resumeObj.updatedAt = Date.now()
+        return res.json({
+          kind,
+          targets,
+          resumed: isResume,
+          done: false,
+          capacityExhausted: true,
+          error: CAPACITY_EXHAUSTED_ERROR,
+          resumeState: resumeObj,
+          ...(storageId ? { storageId } : {}),
+        })
+      }
+      throw error
     }
 
-    const effectiveChunk = Math.max(1, Math.min(safeChunkLimit, remaining))
-    const { profile, usedProfile } = await pickProfile(dist, cleanedProfileId)
+    const { profile, usedProfile } = profileSelection
+    let usedChunkLimit = getChunkLimitForProfile(profile, safeChunkLimit)
+    let usedMaxPages = safeMaxPages
 
     const endpoint = kind === 'followers' ? 'followers' : 'following'
-    let usedChunkLimit = effectiveChunk
-    let usedMaxPages = safeMaxPages
     let result = await fetchScrapeChunk({
       endpoint,
       authUsername: profile.name,
       sessionId: profile.sessionId,
       targetUsername: next.targetUsername,
-      limit: safeLimit,
       chunkLimit: usedChunkLimit,
       maxPages: usedMaxPages,
       cursor: next.cursor,
@@ -187,7 +182,6 @@ export async function handleChunkRequest(
           authUsername: profile.name,
           sessionId: profile.sessionId,
           targetUsername: next.targetUsername,
-          limit: safeLimit,
           chunkLimit: usedChunkLimit,
           maxPages: usedMaxPages,
           cursor: next.cursor,
@@ -226,23 +220,20 @@ export async function handleChunkRequest(
       }
     }
 
-    // Update resume state
     next.scrapedTotal = Math.max(0, next.scrapedTotal + Math.max(0, scraped))
     next.cursor = hasMore ? nextCursor : null
-    next.done = !hasMore || next.scrapedTotal >= safeLimit
+    next.done = !hasMore
     if (next.done) next.cursor = null
 
-    resumeObj.done = resumeObj.perTarget.every((p) => p.done)
+    resumeObj.done = resumeObj.perTarget.every((target) => target.done)
     resumeObj.updatedAt = Date.now()
 
-    // Merge with existing users if resuming
     const existingUsers = await loadExistingUsers(storageId, isResume)
     const mergedUsers = dedupeUsers(isResume ? [...existingUsers, ...users] : users)
 
     const storedStorageId = await storeScrapedDataIfNeeded(taskId, mergedUsers, {
       kind,
-      mode: dist === 'auto' ? 'auto' : 'manual',
-      limit: safeLimit,
+      autoOnly: true,
       chunkLimit: usedChunkLimit,
       maxPages: usedMaxPages,
       targets,
@@ -253,14 +244,10 @@ export async function handleChunkRequest(
         usedProfile,
         hasMore,
       },
-      ...(dist === 'auto' ? { distribution: 'auto' } : {}),
     })
 
     return res.json({
       kind,
-      mode: dist === 'auto' ? 'auto' : 'manual',
-      ...(dist === 'auto' ? { distribution: 'auto' } : { profileId: cleanedProfileId }),
-      limit: safeLimit,
       chunkLimit: usedChunkLimit,
       maxPages: usedMaxPages,
       targets,

--- a/server/api/scraping/followers.ts
+++ b/server/api/scraping/followers.ts
@@ -2,40 +2,32 @@
 
 import { Router } from 'express'
 import { HttpError } from './types.js'
-import { cleanTargets, parseLimit, storeScrapedDataIfNeeded, handleError } from './helpers.js'
+import { cleanTargets, storeScrapedDataIfNeeded, handleError } from './helpers.js'
 import { scrapeOne } from './scrape-core.js'
 
 const router = Router()
 
 router.post('/', async (req, res) => {
   try {
-    const { profileId, targetUsername, targetUsernames, limit, distribution, taskId } = req.body || {}
+    const { targetUsername, targetUsernames, taskId } = req.body || {}
 
     const targets = cleanTargets(targetUsernames ?? targetUsername)
     if (targets.length === 0) {
       return res.status(400).json({ error: 'targetUsername is required' })
     }
 
-    const safeLimit = parseLimit(limit, 200, 1, 5000)
-    const cleanedProfileId = String(profileId || '').trim()
-    const dist = String(distribution || '').trim().toLowerCase()
-
     // Single target
     if (targets.length === 1) {
       const single = await scrapeOne({
         kind: 'followers',
         cleanedTarget: targets[0]!,
-        cleanedProfileId,
-        distribution: dist,
-        safeLimit,
       })
       const singleUsers = Array.isArray((single as any)?.users) ? (single as any).users : []
       
       const storageId = await storeScrapedDataIfNeeded(taskId, singleUsers, {
         targets: [targets[0]],
         kind: 'followers',
-        mode: dist === 'auto' ? 'auto' : 'manual',
-        limit: safeLimit,
+        autoOnly: true,
       })
       
       return res.json({
@@ -51,9 +43,6 @@ router.post('/', async (req, res) => {
         const payload = await scrapeOne({
           kind: 'followers',
           cleanedTarget: t,
-          cleanedProfileId,
-          distribution: dist,
-          safeLimit,
         })
         const scraped =
           typeof (payload as any)?.scraped === 'number'
@@ -79,22 +68,18 @@ router.post('/', async (req, res) => {
     const storageId = await storeScrapedDataIfNeeded(taskId, users, {
       targets,
       kind: 'followers',
-      mode: dist === 'auto' ? 'auto' : 'manual',
-      limit: safeLimit,
+      autoOnly: true,
       perTarget: perTarget.map(r => ({
         targetUsername: r.targetUsername,
         ok: r.ok,
         scraped: r.scraped,
         ...(r.ok ? {} : { error: r.error })
       })),
-      ...(dist === 'auto' ? { distribution: 'auto' } : {}),
     })
 
     return res.json({
       batch: true,
       targets,
-      limit: safeLimit,
-      ...(dist === 'auto' ? { distribution: 'auto' } : {}),
       totalScraped,
       users,
       perTarget,

--- a/server/api/scraping/following.ts
+++ b/server/api/scraping/following.ts
@@ -2,40 +2,32 @@
 
 import { Router } from 'express'
 import { HttpError } from './types.js'
-import { cleanTargets, parseLimit, storeScrapedDataIfNeeded, handleError } from './helpers.js'
+import { cleanTargets, storeScrapedDataIfNeeded, handleError } from './helpers.js'
 import { scrapeOne } from './scrape-core.js'
 
 const router = Router()
 
 router.post('/', async (req, res) => {
   try {
-    const { profileId, targetUsername, targetUsernames, limit, distribution, taskId } = req.body || {}
+    const { targetUsername, targetUsernames, taskId } = req.body || {}
 
     const targets = cleanTargets(targetUsernames ?? targetUsername)
     if (targets.length === 0) {
       return res.status(400).json({ error: 'targetUsername is required' })
     }
 
-    const safeLimit = parseLimit(limit, 200, 1, 5000)
-    const cleanedProfileId = String(profileId || '').trim()
-    const dist = String(distribution || '').trim().toLowerCase()
-
     // Single target
     if (targets.length === 1) {
       const single = await scrapeOne({
         kind: 'following',
         cleanedTarget: targets[0]!,
-        cleanedProfileId,
-        distribution: dist,
-        safeLimit,
       })
       const singleUsers = Array.isArray((single as any)?.users) ? (single as any).users : []
       
       const storageId = await storeScrapedDataIfNeeded(taskId, singleUsers, {
         targets: [targets[0]],
         kind: 'following',
-        mode: dist === 'auto' ? 'auto' : 'manual',
-        limit: safeLimit,
+        autoOnly: true,
       })
       
       return res.json({
@@ -51,9 +43,6 @@ router.post('/', async (req, res) => {
         const payload = await scrapeOne({
           kind: 'following',
           cleanedTarget: t,
-          cleanedProfileId,
-          distribution: dist,
-          safeLimit,
         })
         const scraped =
           typeof (payload as any)?.scraped === 'number'
@@ -79,22 +68,18 @@ router.post('/', async (req, res) => {
     const storageId = await storeScrapedDataIfNeeded(taskId, users, {
       targets,
       kind: 'following',
-      mode: dist === 'auto' ? 'auto' : 'manual',
-      limit: safeLimit,
+      autoOnly: true,
       perTarget: perTarget.map(r => ({
         targetUsername: r.targetUsername,
         ok: r.ok,
         scraped: r.scraped,
         ...(r.ok ? {} : { error: r.error })
       })),
-      ...(dist === 'auto' ? { distribution: 'auto' } : {}),
     })
 
     return res.json({
       batch: true,
       targets,
-      limit: safeLimit,
-      ...(dist === 'auto' ? { distribution: 'auto' } : {}),
       totalScraped,
       users,
       perTarget,

--- a/server/api/scraping/helpers.ts
+++ b/server/api/scraping/helpers.ts
@@ -1,11 +1,13 @@
 // Shared helper functions for scraping API
 
-import { profilesList, profilesGetById, scrapingTasksStoreData, scrapingTasksGetStorageUrl } from '../../data/convex.js'
+import { profilesList, scrapingTasksStoreData, scrapingTasksGetStorageUrl } from '../../data/convex.js'
 import { EligibleProfile, ResumeTarget, ResumeState, HttpError } from './types.js'
 
 export { HttpError } from './types.js'
 
 export const SCRAPER_URL = process.env.SCRAPER_URL || 'http://scraper:3003'
+export const NO_ELIGIBLE_PROFILES_ERROR = 'No eligible profiles with proxy, sessionId, and remaining daily scraping capacity'
+export const CAPACITY_EXHAUSTED_ERROR = 'Daily scraping capacity exhausted before all targets were completed'
 
 // Clean and normalize target usernames from various input formats
 export function cleanTargets(raw: unknown): string[] {
@@ -24,12 +26,12 @@ export function cleanTargets(raw: unknown): string[] {
     .filter(Boolean)
 }
 
-// Get profiles eligible for scraping (automation=false, has sessionId, has proxy, within daily limit)
+// Get profiles eligible for scraping (has sessionId, has proxy, within daily limit)
 export async function getEligibleProfiles(): Promise<EligibleProfile[]> {
   const all = await profilesList()
   const eligible = (all || [])
     .filter((p: any) => {
-      if (!p || p.automation !== false || typeof p.session_id !== 'string' || !p.session_id.trim()) {
+      if (!p || typeof p.session_id !== 'string' || !p.session_id.trim()) {
         return false
       }
       // Require proxy for scraping
@@ -56,6 +58,21 @@ export async function getEligibleProfiles(): Promise<EligibleProfile[]> {
   return eligible
 }
 
+export function getRemainingDailyCapacity(profile: EligibleProfile): number | null {
+  if (profile.dailyLimit === null) {
+    return null
+  }
+  return Math.max(0, profile.dailyLimit - profile.dailyUsed)
+}
+
+export function getChunkLimitForProfile(profile: EligibleProfile, desiredChunkLimit: number): number {
+  const remainingCapacity = getRemainingDailyCapacity(profile)
+  if (remainingCapacity === null) {
+    return Math.max(1, desiredChunkLimit)
+  }
+  return Math.max(1, Math.min(desiredChunkLimit, remainingCapacity))
+}
+
 
 // Store scraped data in Convex file storage
 export async function storeScrapedDataIfNeeded(
@@ -76,43 +93,18 @@ export async function storeScrapedDataIfNeeded(
   }
 }
 
-// Pick a profile for scraping (auto or manual selection)
+// Pick the next eligible profile for auto-only scraping.
 export async function pickProfile(
-  distribution: string,
-  profileId: string
-): Promise<{ profile: { id: string; name: string; sessionId: string; proxy: string }; usedProfile: { id: string; name: string } }> {
-  if (distribution === 'auto') {
-    const eligible = await getEligibleProfiles()
-    if (eligible.length === 0) {
-      throw new HttpError(400, 'No eligible profiles (automation=false, sessionId set, and proxy configured)')
-    }
-    const profile = eligible[0]!
-    return { profile, usedProfile: { id: profile.id, name: profile.name } }
+  started: boolean
+): Promise<{ profile: EligibleProfile; usedProfile: { id: string; name: string } }> {
+  const eligible = await getEligibleProfiles()
+  if (eligible.length === 0) {
+    throw new HttpError(started ? 429 : 400, started ? CAPACITY_EXHAUSTED_ERROR : NO_ELIGIBLE_PROFILES_ERROR)
   }
-
-  if (!profileId) {
-    throw new HttpError(400, 'profileId is required (or use distribution="auto")')
-  }
-  
-  const profile = await profilesGetById(profileId)
-  if (!profile) throw new HttpError(404, 'Profile not found')
-  if (profile.automation === true) throw new HttpError(400, 'Profile automation must be false')
-  
-  const sessionId = String(profile.session_id || '').trim()
-  if (!sessionId) throw new HttpError(400, 'Profile sessionId is missing')
-
-  const proxy = String(profile.proxy || '').trim()
-  if (!proxy) throw new HttpError(400, 'Profile proxy is required for scraping')
-
-  const dailyLimit = typeof profile.daily_scraping_limit === 'number' ? profile.daily_scraping_limit : null
-  const dailyUsed = typeof profile.daily_scraping_used === 'number' ? profile.daily_scraping_used : 0
-  if (dailyLimit !== null && dailyUsed >= dailyLimit) {
-    throw new HttpError(429, `Profile ${profile.name} has reached daily scraping limit (${dailyLimit})`)
-  }
-
+  const profile = eligible[0]!
   return {
-    profile: { id: profileId, name: profile.name, sessionId, proxy },
-    usedProfile: { id: profileId, name: profile.name }
+    profile,
+    usedProfile: { id: profile.id, name: profile.name }
   }
 }
 
@@ -120,20 +112,18 @@ export async function pickProfile(
 export function normalizeResume(
   raw: unknown,
   targets: string[],
-  safeLimit: number,
   kind: 'followers' | 'following',
   isResume: boolean
 ): ResumeState {
   const now = Date.now()
   if (!isResume) {
     const perTarget = targets.map((t) => ({ targetUsername: t, cursor: null, scrapedTotal: 0, done: false }))
-    return { version: 1, kind, limit: safeLimit, perTarget, done: false, updatedAt: now }
+    return { version: 2, kind, perTarget, done: false, updatedAt: now }
   }
 
   const base: ResumeState = {
-    version: 1,
+    version: 2,
     kind,
-    limit: safeLimit,
     perTarget: [],
     done: false,
     updatedAt: now,
@@ -167,7 +157,7 @@ export function normalizeResume(
     const scrapedTotalVal = existing ? existing.scrapedTotal : 0
     const cursorVal = existing ? existing.cursor : null
     const doneVal = existing ? existing.done : false
-    const doneFinal = doneVal || scrapedTotalVal >= safeLimit
+    const doneFinal = doneVal
     return { targetUsername: t, cursor: doneFinal ? null : cursorVal, scrapedTotal: scrapedTotalVal, done: doneFinal }
   })
   base.done = base.perTarget.every((p) => p.done)

--- a/server/api/scraping/scrape-core.ts
+++ b/server/api/scraping/scrape-core.ts
@@ -1,18 +1,24 @@
-// Core scraping logic shared between followers and following endpoints
+// Core scraping logic shared between followers and following endpoints.
 
-import { profilesGetById, profilesIncrementDailyScrapingUsed } from '../../data/convex.js'
-import { HttpError, EligibleProfile } from './types.js'
-import { SCRAPER_URL, getEligibleProfiles } from './helpers.js'
+import { profilesIncrementDailyScrapingUsed } from '../../data/convex.js'
+import { HttpError } from './types.js'
+import {
+  CAPACITY_EXHAUSTED_ERROR,
+  NO_ELIGIBLE_PROFILES_ERROR,
+  SCRAPER_URL,
+  getChunkLimitForProfile,
+  getEligibleProfiles,
+} from './helpers.js'
 
 export type ScrapeKind = 'followers' | 'following'
 
 interface ScrapeOneParams {
   kind: ScrapeKind
   cleanedTarget: string
-  cleanedProfileId: string
-  distribution: string
-  safeLimit: number
 }
+
+const DEFAULT_SCRAPE_CHUNK_LIMIT = 200
+const DEFAULT_SCRAPE_MAX_PAGES = 10
 
 function isHtmlPayload(text: string): boolean {
   const t = String(text || '').trim().toLowerCase()
@@ -22,7 +28,7 @@ function isHtmlPayload(text: string): boolean {
 function sanitizeUpstreamError(status: number, message: string): string {
   const trimmed = String(message || '').trim()
   if (isHtmlPayload(trimmed)) {
-    if (status === 504) return 'Upstream timed out (504). Try smaller limit or check proxy/session.'
+    if (status === 504) return 'Upstream timed out (504). Try a smaller chunk size or check proxy/session.'
     if (status === 502) return 'Upstream unavailable (502). Try again or check SCRAPER_URL.'
     if (status === 503) return 'Upstream unavailable (503). Try again or check SCRAPER_URL.'
     return `Upstream error (${status}).`
@@ -30,216 +36,116 @@ function sanitizeUpstreamError(status: number, message: string): string {
   return trimmed || `Upstream error (${status}).`
 }
 
-// Scrape a single target with auto-distribution across profiles
-async function scrapeWithAutoDistribution(
-  kind: ScrapeKind,
-  cleanedTarget: string,
-  safeLimit: number
-) {
-  const eligible = await getEligibleProfiles()
-  if (eligible.length === 0) {
-    throw new HttpError(400, 'No eligible profiles (automation=false, sessionId set, and proxy configured)')
-  }
-
-  // Sequential distribution: max out each profile before moving to next
-  const tasks: Array<{ profile: EligibleProfile; limit: number }> = []
-  let remainingLimit = safeLimit
-  
-  for (const profile of eligible) {
-    if (remainingLimit <= 0) break
-    
-    let profileLimit = safeLimit
-    if (profile.dailyLimit !== null) {
-      const remaining = profile.dailyLimit - profile.dailyUsed
-      if (remaining <= 0) continue
-      profileLimit = Math.min(profileLimit, remaining)
-    }
-    
-    const taskLimit = Math.min(profileLimit, remainingLimit)
-    if (taskLimit <= 0) continue
-    
-    tasks.push({ profile, limit: taskLimit })
-    remainingLimit -= taskLimit
-  }
-  
-  const chunkSize = safeLimit
+async function scrapeWithAutoDistribution(kind: ScrapeKind, cleanedTarget: string) {
   const endpoint = kind === 'followers' ? 'followers' : 'following'
+  const users: any[] = []
+  const perProfile: Array<{
+    ok: boolean
+    status: number
+    usedProfile: { id: string; name: string }
+    scraped: number
+    error?: string
+  }> = []
 
-  const perProfile = await Promise.all(
-    tasks.map(async (t) => {
-      const resp = await fetch(`${SCRAPER_URL}/scrape/${endpoint}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({
-          auth_username: t.profile.name,
-          session_id: t.profile.sessionId,
-          target_username: cleanedTarget,
-          limit: t.limit,
-          proxy: t.profile.proxy,
-        }),
-      })
+  let cursor: string | null = null
+  let totalScraped = 0
+  let started = false
 
-      const text = await resp.text()
-      let payload: any = null
-      try {
-        payload = text ? JSON.parse(text) : null
-      } catch {
-        payload = null
-      }
-
-      if (!resp.ok) {
-        const message = (payload && (payload.detail || payload.error)) || text || `Scraper error (${resp.status})`
-        return {
-          ok: false as const,
-          status: resp.status,
-          usedProfile: { id: t.profile.id, name: t.profile.name },
-          scraped: 0,
-          error: sanitizeUpstreamError(resp.status, String(message)),
-        }
-      }
-
-      const users = payload?.users
-      const scraped = typeof payload?.scraped === 'number' ? payload.scraped : Array.isArray(users) ? users.length : 0
-
-      if (scraped > 0) {
-        try {
-          await profilesIncrementDailyScrapingUsed(t.profile.name, scraped)
-        } catch (err) {
-          console.error(`Failed to increment daily scraping for ${t.profile.name}:`, err)
-        }
+  while (true) {
+    const eligible = await getEligibleProfiles()
+    if (eligible.length === 0) {
+      if (!started) {
+        throw new HttpError(400, NO_ELIGIBLE_PROFILES_ERROR)
       }
 
       return {
-        ok: true as const,
-        status: resp.status,
-        usedProfile: { id: t.profile.id, name: t.profile.name },
-        scraped,
-        users: Array.isArray(users) ? users : [],
+        targetUsername: cleanedTarget,
+        totalScraped,
+        users,
+        perProfile,
+        partial: true,
+        completed: false,
+        capacityExhausted: true,
+        error: CAPACITY_EXHAUSTED_ERROR,
       }
+    }
+
+    const profile = eligible[0]!
+    const chunkLimit = getChunkLimitForProfile(profile, DEFAULT_SCRAPE_CHUNK_LIMIT)
+
+    const resp = await fetch(`${SCRAPER_URL}/scrape/${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        auth_username: profile.name,
+        session_id: profile.sessionId,
+        target_username: cleanedTarget,
+        chunk_limit: chunkLimit,
+        max_pages: DEFAULT_SCRAPE_MAX_PAGES,
+        cursor,
+        proxy: profile.proxy,
+      }),
     })
-  )
 
-  const users = perProfile.flatMap((r: any) => (r && r.ok && Array.isArray(r.users) ? r.users : []))
-  const totalScraped = perProfile.reduce((sum: number, r: any) => sum + (typeof r?.scraped === 'number' ? r.scraped : 0), 0)
-  const failures = perProfile.filter((r: any) => !r?.ok)
-
-  return {
-    distribution: 'auto',
-    targetUsername: cleanedTarget,
-    limit: safeLimit,
-    eligibleCount: eligible.length,
-    chunkSize,
-    totalScraped,
-    users,
-    perProfile: perProfile.map((r: any) => {
-      if (r?.ok) {
-        return { ok: true, status: r.status, usedProfile: r.usedProfile, scraped: r.scraped }
-      }
-      return { ok: false, status: r?.status ?? 0, usedProfile: r?.usedProfile, scraped: 0, error: r?.error ?? 'Unknown error' }
-    }),
-    ...(failures.length > 0 ? { partial: true, failures: failures.length } : {}),
-  }
-}
-
-
-// Scrape a single target with a specific profile
-async function scrapeWithProfile(
-  kind: ScrapeKind,
-  cleanedTarget: string,
-  cleanedProfileId: string,
-  safeLimit: number
-) {
-  const profile = await profilesGetById(cleanedProfileId)
-  if (!profile) {
-    throw new HttpError(404, 'Profile not found')
-  }
-  if (profile.automation === true) {
-    throw new HttpError(400, 'Profile automation must be false')
-  }
-  const sessionId = String(profile.session_id || '').trim()
-  if (!sessionId) {
-    throw new HttpError(400, 'Profile sessionId is missing')
-  }
-
-  // Check proxy is configured
-  const proxy = String(profile.proxy || '').trim()
-  if (!proxy) {
-    throw new HttpError(400, 'Profile proxy is required for scraping')
-  }
-
-  // Check daily scraping limit
-  const dailyLimit = typeof profile.daily_scraping_limit === 'number' ? profile.daily_scraping_limit : null
-  const dailyUsed = typeof profile.daily_scraping_used === 'number' ? profile.daily_scraping_used : 0
-  if (dailyLimit !== null && dailyUsed >= dailyLimit) {
-    throw new HttpError(429, `Profile ${profile.name} has reached daily scraping limit (${dailyLimit})`)
-  }
-
-  // Adjust limit if it would exceed daily limit
-  let effectiveLimit = safeLimit
-  if (dailyLimit !== null) {
-    const remaining = dailyLimit - dailyUsed
-    effectiveLimit = Math.min(safeLimit, remaining)
-    if (effectiveLimit <= 0) {
-      throw new HttpError(429, `Profile ${profile.name} has no remaining daily scraping capacity`)
-    }
-  }
-
-  const endpoint = kind === 'followers' ? 'followers' : 'following'
-  const resp = await fetch(`${SCRAPER_URL}/scrape/${endpoint}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify({
-      auth_username: profile.name,
-      session_id: sessionId,
-      target_username: cleanedTarget,
-      limit: effectiveLimit,
-      proxy: proxy,
-    }),
-  })
-
-  const text = await resp.text()
-  let payload: any = null
-  try {
-    payload = text ? JSON.parse(text) : null
-  } catch {
-    payload = null
-  }
-
-  if (!resp.ok) {
-    const message = (payload && (payload.detail || payload.error)) || text || `Scraper error (${resp.status})`
-    throw new HttpError(resp.status, sanitizeUpstreamError(resp.status, String(message)))
-  }
-
-  const scraped = typeof payload?.scraped === 'number' ? payload.scraped : Array.isArray(payload?.users) ? payload.users.length : 0
-  
-  if (scraped > 0) {
+    const text = await resp.text()
+    let payload: any = null
     try {
-      await profilesIncrementDailyScrapingUsed(profile.name, scraped)
-    } catch (err) {
-      console.error(`Failed to increment daily scraping for ${profile.name}:`, err)
+      payload = text ? JSON.parse(text) : null
+    } catch {
+      payload = null
     }
-  }
 
-  return {
-    ...(payload ?? {}),
-    usedProfile: { id: cleanedProfileId, name: profile.name },
+    if (!resp.ok) {
+      const message = (payload && (payload.detail || payload.error)) || text || `Scraper error (${resp.status})`
+      throw new HttpError(resp.status, sanitizeUpstreamError(resp.status, String(message)))
+    }
+
+    const chunkUsers = Array.isArray(payload?.users) ? payload.users : []
+    const scraped = typeof payload?.scraped === 'number' ? payload.scraped : chunkUsers.length
+    const nextCursor =
+      typeof payload?.nextCursor === 'string' && payload.nextCursor.trim()
+        ? payload.nextCursor.trim()
+        : null
+    const hasMore = Boolean(payload?.hasMore) && Boolean(nextCursor)
+
+    started = true
+    totalScraped += scraped
+    users.push(...chunkUsers)
+    perProfile.push({
+      ok: true,
+      status: resp.status,
+      usedProfile: { id: profile.id, name: profile.name },
+      scraped,
+    })
+
+    if (scraped > 0) {
+      try {
+        await profilesIncrementDailyScrapingUsed(profile.name, scraped)
+      } catch (err) {
+        console.error(`Failed to increment daily scraping for ${profile.name}:`, err)
+      }
+    }
+
+    if (!hasMore) {
+      return {
+        targetUsername: cleanedTarget,
+        totalScraped,
+        users,
+        perProfile,
+        completed: true,
+      }
+    }
+
+    cursor = nextCursor
   }
 }
 
-// Main scrape function that handles both auto and manual distribution
 export async function scrapeOne(params: ScrapeOneParams) {
-  const { kind, cleanedTarget, cleanedProfileId, distribution, safeLimit } = params
-  
+  const { kind, cleanedTarget } = params
+
   if (!cleanedTarget) {
     throw new HttpError(400, 'targetUsername is required')
   }
 
-  if (!cleanedProfileId) {
-    if (distribution !== 'auto') {
-      throw new HttpError(400, 'profileId is required (or use distribution="auto")')
-    }
-    return scrapeWithAutoDistribution(kind, cleanedTarget, safeLimit)
-  }
-
-  return scrapeWithProfile(kind, cleanedTarget, cleanedProfileId, safeLimit)
+  return scrapeWithAutoDistribution(kind, cleanedTarget)
 }

--- a/server/api/scraping/types.ts
+++ b/server/api/scraping/types.ts
@@ -17,9 +17,8 @@ export type ResumeTarget = {
 }
 
 export type ResumeState = {
-  version: 1
+  version: 2
   kind: 'followers' | 'following'
-  limit: number
   perTarget: ResumeTarget[]
   done: boolean
   updatedAt: number

--- a/server/data/convex.ts
+++ b/server/data/convex.ts
@@ -33,7 +33,6 @@ export type DbProfileRow = {
     name: string;
     proxy?: string | null;
     proxy_type?: string | null;
-    automation?: boolean | null;
     status?: string | null;
     mode?: string | null;
     session_id?: string | null;
@@ -55,7 +54,6 @@ export type ProfileInput = {
     fingerprint_seed?: string;
     fingerprint_os?: string;
     test_ip?: boolean;
-    automation?: boolean;
     daily_scraping_limit?: number | null;
 };
 
@@ -131,7 +129,6 @@ export async function profilesCreate(profile: ProfileInput): Promise<DbProfileRo
             fingerprintSeed: profile.fingerprint_seed,
             fingerprintOs: profile.fingerprint_os,
             testIp: profile.test_ip,
-            automation: profile.automation,
             dailyScrapingLimit: profile.daily_scraping_limit,
         },
     });
@@ -152,7 +149,6 @@ export async function profilesUpdateByName(oldName: string, profile: ProfileInpu
             fingerprintSeed: profile.fingerprint_seed,
             fingerprintOs: profile.fingerprint_os,
             testIp: profile.test_ip,
-            automation: profile.automation,
             dailyScrapingLimit: profile.daily_scraping_limit,
         },
     });

--- a/server/data/profiles.ts
+++ b/server/data/profiles.ts
@@ -16,7 +16,6 @@ export type Profile = {
 	fingerprint_seed?: string;
 	fingerprint_os?: string;
 	test_ip?: boolean;
-	automation?: boolean;
 	status?: string;
 	using?: boolean;
 	login?: boolean;
@@ -37,7 +36,6 @@ export class ProfileManager {
 				fingerprint_seed: p.fingerprint_seed,
 				fingerprint_os: p.fingerprint_os,
 				test_ip: p.test_ip,
-				automation: Boolean(p.automation),
 				status: p.status,
 				using: p.Using,
 				login: p.login,
@@ -117,7 +115,6 @@ export class ProfileManager {
 				fingerprint_seed: profile.fingerprint_seed,
 				fingerprint_os: profile.fingerprint_os,
 				test_ip: profile.test_ip,
-				automation: profile.automation,
 				daily_scraping_limit: profile.daily_scraping_limit,
 			});
 		} catch (e) {
@@ -141,7 +138,6 @@ export class ProfileManager {
 				fingerprint_seed: profile.fingerprint_seed,
 				fingerprint_os: profile.fingerprint_os,
 				test_ip: profile.test_ip,
-				automation: profile.automation,
 				daily_scraping_limit: profile.daily_scraping_limit,
 			});
 		} catch (e) {

--- a/server/scripts/migrate-scraper-auto-only.ts
+++ b/server/scripts/migrate-scraper-auto-only.ts
@@ -1,0 +1,147 @@
+import {
+  analyzeCohorts,
+  buildSnapshot,
+  convexMutation,
+  fetchProfiles,
+  fetchTasks,
+  getSampleLimit,
+  parseCliArgs,
+  resolveOutputPath,
+  sampleIds,
+  writeJson,
+} from './scraper-auto-only-shared.js'
+
+type ProfileCleanupResult = {
+  updated: boolean
+  removedAutomation: boolean
+}
+
+type TaskCleanupResult = {
+  updated: boolean
+  removedLegacyFields: number
+  resetToIdle: boolean
+  clearedRuntimeState: boolean
+  unknownLastOutputShape: boolean
+}
+
+function assertMode(args: Record<string, string | boolean>): 'dry-run' | 'apply' {
+  const dryRun = args['dry-run'] === true
+  const apply = args.apply === true
+  if (dryRun === apply) {
+    throw new Error('Pass exactly one of --dry-run or --apply')
+  }
+  if (apply && args.confirm !== 'scraper-auto-only') {
+    throw new Error('Apply requires --confirm scraper-auto-only')
+  }
+  return dryRun ? 'dry-run' : 'apply'
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArgs(process.argv.slice(2))
+  const mode = assertMode(args)
+  const sampleLimit = getSampleLimit(args)
+  const outputPath = resolveOutputPath(
+    typeof args.output === 'string' ? args.output : undefined,
+    mode === 'dry-run' ? 'scraper-auto-only-dry-run' : 'scraper-auto-only-apply',
+  )
+  const snapshotPath = mode === 'apply'
+    ? resolveOutputPath(
+        typeof args.snapshot === 'string' ? args.snapshot : undefined,
+        'scraper-auto-only-before',
+      )
+    : undefined
+
+  const profilesBefore = await fetchProfiles()
+  const tasksBefore = await fetchTasks()
+  const analysisBefore = analyzeCohorts(profilesBefore, tasksBefore)
+
+  const evidence: Record<string, unknown> = {
+    ts_utc: new Date().toISOString(),
+    issue: 9,
+    mode,
+    sample_limit: sampleLimit,
+    snapshot_path: snapshotPath ?? null,
+    counts_before: {
+      profiles_with_automation_before: analysisBefore.profileCleanupIds.length,
+      tasks_with_legacy_fields_before: analysisBefore.taskLegacyFieldIds.length,
+      tasks_reset_to_idle_total: analysisBefore.taskResetIds.length,
+      tasks_runtime_state_cleared_total: analysisBefore.taskRuntimeCleanupIds.length,
+      unknown_last_output_shape_total: analysisBefore.unknownLastOutputShapeIds.length,
+      eligible_profiles_after: analysisBefore.eligibleProfilesAfter.length,
+    },
+    sample_ids: {
+      profiles: sampleIds(analysisBefore.profileCleanupIds, Math.min(sampleLimit, 3)),
+      tasks: sampleIds(
+        Array.from(new Set([
+          ...analysisBefore.taskLegacyFieldIds,
+          ...analysisBefore.taskResetIds,
+          ...analysisBefore.taskRuntimeCleanupIds,
+        ])),
+        Math.min(sampleLimit, 3),
+      ),
+      unknown_last_output_shape_tasks: sampleIds(analysisBefore.unknownLastOutputShapeIds, sampleLimit),
+    },
+    output_path: outputPath,
+  }
+
+  if (mode === 'dry-run') {
+    await writeJson(outputPath, evidence)
+    console.log(JSON.stringify(evidence, null, 2))
+    return
+  }
+
+  const snapshot = buildSnapshot(profilesBefore, tasksBefore, analysisBefore)
+  await writeJson(snapshotPath!, snapshot)
+
+  const profileResults: ProfileCleanupResult[] = []
+  for (const profileId of analysisBefore.profileCleanupIds) {
+    const result = await convexMutation<ProfileCleanupResult>('migrations:scraperAutoOnlyApplyProfileCleanup', {
+      profileId,
+    })
+    profileResults.push(result)
+  }
+
+  const taskIds = Array.from(new Set([
+    ...analysisBefore.taskLegacyFieldIds,
+    ...analysisBefore.taskResetIds,
+    ...analysisBefore.taskRuntimeCleanupIds,
+  ]))
+  const taskResults: Array<TaskCleanupResult & { taskId: string }> = []
+  for (const taskId of taskIds) {
+    const result = await convexMutation<TaskCleanupResult>('migrations:scraperAutoOnlyApplyTaskCleanup', {
+      taskId,
+    })
+    taskResults.push({ taskId, ...result })
+  }
+
+  const profilesAfter = await fetchProfiles()
+  const tasksAfter = await fetchTasks()
+  const analysisAfter = analyzeCohorts(profilesAfter, tasksAfter)
+
+  evidence.snapshot_path = snapshotPath
+  evidence.apply_results = {
+    profiles_removed_automation_total: profileResults.filter((result) => result.removedAutomation).length,
+    tasks_removed_legacy_fields_total: taskResults.reduce((total, result) => total + result.removedLegacyFields, 0),
+    tasks_reset_to_idle_total: taskResults.filter((result) => result.resetToIdle).length,
+    tasks_runtime_state_cleared_total: taskResults.filter((result) => result.clearedRuntimeState).length,
+    unknown_last_output_shape_total: taskResults.filter((result) => result.unknownLastOutputShape).length,
+    unknown_last_output_shape_ids: taskResults
+      .filter((result) => result.unknownLastOutputShape)
+      .map((result) => result.taskId),
+  }
+  evidence.counts_after = {
+    profiles_with_automation_after: analysisAfter.profileCleanupIds.length,
+    tasks_with_legacy_fields_after: analysisAfter.taskLegacyFieldIds.length,
+    tasks_still_running_or_paused_after: analysisAfter.taskResetIds.length,
+    tasks_runtime_state_remaining_after: analysisAfter.taskRuntimeCleanupIds.length,
+    eligible_profiles_after: analysisAfter.eligibleProfilesAfter.length,
+  }
+
+  await writeJson(outputPath, evidence)
+  console.log(JSON.stringify(evidence, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/server/scripts/rollback-scraper-auto-only.ts
+++ b/server/scripts/rollback-scraper-auto-only.ts
@@ -1,0 +1,84 @@
+import {
+  convexMutation,
+  parseCliArgs,
+  readJson,
+  resolveOutputPath,
+  writeJson,
+} from './scraper-auto-only-shared.js'
+
+type SnapshotPayload = {
+  ts_utc: string
+  issue: number
+  kind: string
+  profiles: Array<{
+    _id: string
+    name?: string
+    automation?: boolean | null
+    hadAutomation: boolean
+  }>
+  tasks: Array<Record<string, unknown> & { _id: string }>
+}
+
+function requireSnapshotPath(args: Record<string, string | boolean>): string {
+  if (typeof args.snapshot !== 'string' || !args.snapshot.trim()) {
+    throw new Error('Rollback requires --snapshot <path>')
+  }
+  return args.snapshot
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArgs(process.argv.slice(2))
+  const snapshotPath = requireSnapshotPath(args)
+  const outputPath = resolveOutputPath(
+    typeof args.output === 'string' ? args.output : undefined,
+    'scraper-auto-only-rollback',
+  )
+  const snapshot = await readJson<SnapshotPayload>(snapshotPath)
+
+  if (snapshot.kind !== 'scraper-auto-only-pre-apply-snapshot') {
+    throw new Error('Snapshot kind is not scraper-auto-only-pre-apply-snapshot')
+  }
+
+  const profileResults: Array<{ profileId: string; restored: boolean }> = []
+  for (const profile of snapshot.profiles || []) {
+    const result = await convexMutation<{ restored: boolean }>('migrations:scraperAutoOnlyRollbackProfile', {
+      profileId: profile._id,
+      hadAutomation: Boolean(profile.hadAutomation),
+      automation: typeof profile.automation === 'boolean' ? profile.automation : null,
+    })
+    profileResults.push({ profileId: profile._id, restored: result.restored })
+  }
+
+  const taskResults: Array<{ taskId: string; restored: boolean }> = []
+  for (const task of snapshot.tasks || []) {
+    const result = await convexMutation<{ restored: boolean }>('migrations:scraperAutoOnlyRollbackTask', {
+      taskId: task._id,
+      snapshot: task,
+    })
+    taskResults.push({ taskId: task._id, restored: result.restored })
+  }
+
+  const evidence = {
+    ts_utc: new Date().toISOString(),
+    issue: 9,
+    mode: 'rollback',
+    snapshot_path: snapshotPath,
+    output_path: outputPath,
+    profiles_requested: snapshot.profiles.length,
+    tasks_requested: snapshot.tasks.length,
+    profiles_restored: profileResults.filter((result) => result.restored).length,
+    tasks_restored: taskResults.filter((result) => result.restored).length,
+    sample_ids: {
+      profiles: profileResults.slice(0, 3).map((result) => result.profileId),
+      tasks: taskResults.slice(0, 3).map((result) => result.taskId),
+    },
+  }
+
+  await writeJson(outputPath, evidence)
+  console.log(JSON.stringify(evidence, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/server/scripts/scraper-auto-only-shared.ts
+++ b/server/scripts/scraper-auto-only-shared.ts
@@ -1,0 +1,276 @@
+import dotenv from 'dotenv'
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..', '..')
+
+dotenv.config({ quiet: true })
+dotenv.config({ path: path.resolve(repoRoot, '.env'), quiet: true })
+dotenv.config({ path: path.resolve(repoRoot, '.env.local'), quiet: true })
+
+export type LegacyProfileRow = Record<string, unknown> & {
+  _id: string
+  name?: string
+  proxy?: string | null
+  sessionId?: string | null
+  dailyScrapingLimit?: number | null
+  dailyScrapingUsed?: number | null
+}
+
+export type LegacyTaskRow = Record<string, unknown> & {
+  _id: string
+  name?: string
+  status?: string | null
+  lastOutput?: unknown
+}
+
+export type CohortAnalysis = {
+  profileCleanupIds: string[]
+  taskLegacyFieldIds: string[]
+  taskResetIds: string[]
+  taskRuntimeCleanupIds: string[]
+  unknownLastOutputShapeIds: string[]
+  eligibleProfilesAfter: string[]
+}
+
+export type SnapshotPayload = {
+  ts_utc: string
+  issue: number
+  kind: 'scraper-auto-only-pre-apply-snapshot'
+  profiles: Array<{
+    _id: string
+    name?: string
+    automation?: boolean | null
+    hadAutomation: boolean
+  }>
+  tasks: LegacyTaskRow[]
+}
+
+const LEGACY_LAST_OUTPUT_KEYS = ['mode', 'distribution', 'profileId', 'limit'] as const
+const LEGACY_RESUME_KEYS = ['mode', 'distribution', 'profileId', 'limit'] as const
+
+function hasOwn(doc: unknown, key: string): boolean {
+  return typeof doc === 'object' && doc !== null && Object.prototype.hasOwnProperty.call(doc, key)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function utcTimestamp(): string {
+  return new Date().toISOString()
+}
+
+export function defaultEvidencePath(prefix: string): string {
+  const safe = utcTimestamp().replace(/[:.]/g, '-')
+  return path.resolve(process.cwd(), `../data/migrations/${prefix}-${safe}.json`)
+}
+
+export function resolveOutputPath(inputPath: string | undefined, fallbackPrefix: string): string {
+  if (inputPath && inputPath.trim()) {
+    return path.resolve(process.cwd(), inputPath)
+  }
+  return defaultEvidencePath(fallbackPrefix)
+}
+
+export async function ensureParentDir(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+}
+
+export async function writeJson(filePath: string, data: unknown): Promise<void> {
+  await ensureParentDir(filePath)
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+export async function readJson<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+function getConvexUrl(): string {
+  const url = process.env.CONVEX_URL
+  if (!url) {
+    throw new Error('CONVEX_URL is required')
+  }
+  return url
+}
+
+async function convexHttp<T>(kind: 'query' | 'mutation', pathName: string, args: Record<string, unknown>): Promise<T> {
+  const response = await fetch(`${getConvexUrl()}/api/${kind}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      path: pathName,
+      args,
+      format: 'json',
+    }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Convex ${kind} ${pathName} failed with ${response.status}: ${text}`)
+  }
+
+  const payload = await response.json() as {
+    status?: string
+    value?: T
+    errorMessage?: string
+  }
+
+  if (payload.status === 'error') {
+    throw new Error(payload.errorMessage || `Convex ${kind} ${pathName} failed`)
+  }
+
+  return payload.value as T
+}
+
+export async function convexQuery<T>(pathName: string, args: Record<string, unknown> = {}): Promise<T> {
+  return convexHttp<T>('query', pathName, args)
+}
+
+export async function convexMutation<T>(pathName: string, args: Record<string, unknown> = {}): Promise<T> {
+  return convexHttp<T>('mutation', pathName, args)
+}
+
+export async function fetchProfiles(): Promise<LegacyProfileRow[]> {
+  return convexQuery<LegacyProfileRow[]>('profiles:list', {})
+}
+
+export async function fetchTasks(): Promise<LegacyTaskRow[]> {
+  return convexQuery<LegacyTaskRow[]>('scrapingTasks:list', {})
+}
+
+function hasLegacyRuntimeState(lastOutput: unknown): { legacy: boolean; unknownShape: boolean } {
+  if (typeof lastOutput === 'undefined' || lastOutput === null) {
+    return { legacy: false, unknownShape: false }
+  }
+
+  if (!isRecord(lastOutput)) {
+    return { legacy: false, unknownShape: true }
+  }
+
+  for (const key of LEGACY_LAST_OUTPUT_KEYS) {
+    if (hasOwn(lastOutput, key)) {
+      return { legacy: true, unknownShape: false }
+    }
+  }
+
+  if (!hasOwn(lastOutput, 'resumeState')) {
+    return { legacy: false, unknownShape: false }
+  }
+
+  const resumeState = lastOutput.resumeState
+  if (resumeState === null || typeof resumeState === 'undefined') {
+    return { legacy: false, unknownShape: false }
+  }
+
+  if (!isRecord(resumeState)) {
+    return { legacy: true, unknownShape: true }
+  }
+
+  const legacyResume = LEGACY_RESUME_KEYS.some((key) => hasOwn(resumeState, key))
+  return { legacy: legacyResume, unknownShape: false }
+}
+
+function hasRemainingCapacity(profile: LegacyProfileRow): boolean {
+  const limit = typeof profile.dailyScrapingLimit === 'number' ? profile.dailyScrapingLimit : null
+  const used = typeof profile.dailyScrapingUsed === 'number' ? profile.dailyScrapingUsed : 0
+  if (limit === null) {
+    return true
+  }
+  return used < limit
+}
+
+function isEligibleProfile(profile: LegacyProfileRow): boolean {
+  const proxy = typeof profile.proxy === 'string' ? profile.proxy.trim() : ''
+  const sessionId = typeof profile.sessionId === 'string' ? profile.sessionId.trim() : ''
+  return Boolean(proxy) && Boolean(sessionId) && hasRemainingCapacity(profile)
+}
+
+export function analyzeCohorts(profiles: LegacyProfileRow[], tasks: LegacyTaskRow[]): CohortAnalysis {
+  const profileCleanupIds = profiles.filter((profile) => hasOwn(profile, 'automation')).map((profile) => profile._id)
+  const taskLegacyFieldIds = tasks
+    .filter((task) => hasOwn(task, 'mode') || hasOwn(task, 'profileId') || hasOwn(task, 'limit'))
+    .map((task) => task._id)
+  const taskResetIds = tasks
+    .filter((task) => {
+      const status = String(task.status ?? '').toLowerCase()
+      return status === 'running' || status === 'paused'
+    })
+    .map((task) => task._id)
+  const taskRuntime = tasks.map((task) => ({
+    taskId: task._id,
+    analysis: hasLegacyRuntimeState(task.lastOutput),
+  }))
+  const taskRuntimeCleanupIds = taskRuntime.filter((entry) => entry.analysis.legacy).map((entry) => entry.taskId)
+  const unknownLastOutputShapeIds = taskRuntime.filter((entry) => entry.analysis.unknownShape).map((entry) => entry.taskId)
+  const eligibleProfilesAfter = profiles.filter(isEligibleProfile).map((profile) => profile._id)
+
+  return {
+    profileCleanupIds,
+    taskLegacyFieldIds,
+    taskResetIds,
+    taskRuntimeCleanupIds,
+    unknownLastOutputShapeIds,
+    eligibleProfilesAfter,
+  }
+}
+
+export function buildSnapshot(profiles: LegacyProfileRow[], tasks: LegacyTaskRow[], analysis: CohortAnalysis): SnapshotPayload {
+  const taskIds = new Set([
+    ...analysis.taskLegacyFieldIds,
+    ...analysis.taskResetIds,
+    ...analysis.taskRuntimeCleanupIds,
+  ])
+
+  return {
+    ts_utc: utcTimestamp(),
+    issue: 9,
+    kind: 'scraper-auto-only-pre-apply-snapshot',
+    profiles: profiles
+      .filter((profile) => analysis.profileCleanupIds.includes(profile._id))
+      .map((profile) => ({
+        _id: profile._id,
+        name: typeof profile.name === 'string' ? profile.name : undefined,
+        automation: typeof profile.automation === 'boolean' ? profile.automation : null,
+        hadAutomation: hasOwn(profile, 'automation'),
+      })),
+    tasks: tasks.filter((task) => taskIds.has(task._id)),
+  }
+}
+
+export function sampleIds(ids: string[], sampleLimit: number): string[] {
+  return ids.slice(0, Math.max(0, sampleLimit))
+}
+
+export function parseCliArgs(argv: string[]): Record<string, string | boolean> {
+  const parsed: Record<string, string | boolean> = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token.startsWith('--')) {
+      continue
+    }
+    const key = token.slice(2)
+    const next = argv[index + 1]
+    if (!next || next.startsWith('--')) {
+      parsed[key] = true
+      continue
+    }
+    parsed[key] = next
+    index += 1
+  }
+  return parsed
+}
+
+export function getSampleLimit(args: Record<string, string | boolean>): number {
+  const raw = typeof args.sample === 'string' ? Number(args.sample) : 20
+  if (!Number.isFinite(raw)) {
+    return 20
+  }
+  return Math.max(1, Math.min(50, Math.floor(raw)))
+}


### PR DESCRIPTION
Refs #9

## Summary
- remove the legacy scraper manual-assignment model across Convex, server, frontend, and scraper runtime
- add auto-only migration and rollback scripts with dry-run/apply evidence capture
- execute dev migration apply and capture pre/post evidence under `data/migrations/`

## Verification
- npm --prefix server run build
- npm --prefix frontend run lint
- npm --prefix frontend run build
- npx convex dev
- migration dry-run/apply/post-apply validation on dev