### PR TITLE
Add Convex self-test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Operations:
 
 - `npm run dev` (root)
 - `npm run build` (root)
+- `npm run test:convex`
 - `npm --prefix frontend run dev`
 - `npm --prefix frontend run build`
 - `npm --prefix frontend run lint`
@@ -60,6 +61,7 @@ Operations:
 - React components: `PascalCase` filenames.
 - Hooks: `useX.ts` naming.
 - Python: PEP 8 and snake_case naming.
+- For Convex changes, run `npm run test:convex` and add or update relevant tests in `convex/tests/`.
 - For frontend/server changes without dedicated tests, run lint + build.
 - Add/update tests when changing automation behavior, parsing, retries, or state handling.
 

--- a/convex/tests/convex.config.test.ts
+++ b/convex/tests/convex.config.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+test('registers the crons component in the Convex app definition', async () => {
+  const use = vi.fn()
+  const cronsComponent = { name: 'crons-component' }
+
+  vi.doMock('convex/server', () => ({
+    defineApp: () => ({ use }),
+  }))
+  vi.doMock('@convex-dev/crons/convex.config.js', () => ({
+    default: cronsComponent,
+  }))
+
+  const { default: app } = await import('../convex.config')
+
+  expect(app).toBeDefined()
+  expect(use).toHaveBeenCalledWith(cronsComponent)
+})

--- a/convex/tests/crons.test.ts
+++ b/convex/tests/crons.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { internal } from '../_generated/api'
+import { createConvexTest, insertDoc } from './helpers'
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.doUnmock('convex/server')
+  vi.doUnmock('../_generated/api')
+  vi.resetModules()
+})
+
+test('registers the expected daily cron jobs', async () => {
+  const daily = vi.fn()
+
+  vi.doMock('convex/server', async () => {
+    const actual = await vi.importActual<typeof import('convex/server')>('convex/server')
+    return {
+      ...actual,
+      cronJobs: () => ({ daily }),
+    }
+  })
+  vi.doMock('../_generated/api', async () => {
+    const actual = await vi.importActual<typeof import('../_generated/api')>('../_generated/api')
+    return {
+      ...actual,
+      internal: {
+        profiles: { resetDailyScrapingUsed: 'profiles.resetDailyScrapingUsed' },
+        instagramAccounts: {
+          autoUnsubscribe: 'instagramAccounts.autoUnsubscribe',
+          assignAvailableAccountsDaily: 'instagramAccounts.assignAvailableAccountsDaily',
+        },
+        workflows: { resetDailyRuns: 'workflows.resetDailyRuns' },
+      },
+    }
+  })
+
+  await import('../crons')
+
+  expect(daily.mock.calls).toEqual([
+    ['reset daily scraping', { hourUTC: 0, minuteUTC: 1 }, 'profiles.resetDailyScrapingUsed'],
+    ['auto unsubscribe', { hourUTC: 3, minuteUTC: 0 }, 'instagramAccounts.autoUnsubscribe'],
+    ['assign accounts', { hourUTC: 3, minuteUTC: 15 }, 'instagramAccounts.assignAvailableAccountsDaily'],
+    ['reset workflow daily runs', { hourUTC: 0, minuteUTC: 2 }, 'workflows.resetDailyRuns'],
+  ])
+})
+
+describe('cron targets', () => {
+  test('resets daily scraping usage for profiles', async () => {
+    const t = createConvexTest()
+    const profile = await insertDoc(t, 'profiles', {
+      createdAt: Date.now(),
+      name: 'Profile A',
+      using: false,
+      testIp: false,
+      login: true,
+      mode: 'direct',
+      listIds: [],
+      dailyScrapingUsed: 12,
+    })
+
+    await t.mutation(internal.profiles.resetDailyScrapingUsed, {})
+
+    const updated = await t.run(async (ctx) => ctx.db.get(profile!._id))
+    expect(updated?.dailyScrapingUsed).toBe(0)
+  })
+
+  test('auto-unsubscribes stale subscribed accounts', async () => {
+    const t = createConvexTest()
+    const account = await insertDoc(t, 'instagramAccounts', {
+      userName: 'user-a',
+      createdAt: Date.now(),
+      status: 'subscribed',
+      message: false,
+      subscribedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+    })
+
+    await t.action(internal.instagramAccounts.autoUnsubscribe, {})
+
+    const updated = await t.run(async (ctx) => ctx.db.get(account!._id))
+    expect(updated?.status).toBe('unsubscribed')
+  })
+
+  test('resets daily workflow run counters', async () => {
+    const t = createConvexTest()
+    const workflow = await insertDoc(t, 'workflows', {
+      name: 'Workflow A',
+      description: 'cron target',
+      nodes: [],
+      edges: [],
+      listIds: [],
+      status: 'idle',
+      isActive: true,
+      runsToday: 4,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+
+    const result = await t.mutation(internal.workflows.resetDailyRuns, {})
+    const updated = await t.run(async (ctx) => ctx.db.get(workflow!._id))
+
+    expect(result).toEqual({ reset: 1 })
+    expect(updated?.runsToday).toBe(0)
+  })
+})

--- a/convex/tests/dashboard.test.ts
+++ b/convex/tests/dashboard.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest, insertDoc, seedList } from './helpers'
+
+test('reports dashboard totals and recent profile activity', async () => {
+  const t = createConvexTest()
+  await seedList(t, 'List A')
+  await insertDoc(t, 'profiles', {
+    createdAt: Date.now(),
+    name: 'Profile A',
+    using: false,
+    testIp: false,
+    login: true,
+    mode: 'direct',
+    listIds: [],
+  })
+  await insertDoc(t, 'instagramAccounts', {
+    userName: 'user-a',
+    createdAt: Date.now(),
+    status: 'available',
+    message: false,
+  })
+
+  const stats = await t.query(api.dashboard.getStats, {})
+
+  expect(stats.totalProfiles).toBe(1)
+  expect(stats.activeLists).toBe(1)
+  expect(stats.instagramActions).toBe(1)
+  expect(stats.recentActivity).toHaveLength(1)
+  expect(stats.recentActivity[0]).toMatchObject({
+    action: 'Profile Updated',
+    details: 'Profile A',
+  })
+})

--- a/convex/tests/helpers.ts
+++ b/convex/tests/helpers.ts
@@ -1,0 +1,73 @@
+import { convexTest } from 'convex-test'
+
+import { api } from '../_generated/api'
+import schema from '../schema'
+
+export const modules = import.meta.glob([
+  '../**/*.ts',
+  '../_generated/*.js',
+  '!../tests/**',
+])
+
+export function createConvexTest() {
+  return convexTest(schema, modules)
+}
+
+export async function insertDoc(
+  t: ReturnType<typeof createConvexTest>,
+  table:
+    | 'instagramAccounts'
+    | 'keywords'
+    | 'lists'
+    | 'messageTemplates'
+    | 'profiles'
+    | 'scrapingTasks'
+    | 'workflows',
+  value: Record<string, unknown>
+) {
+  const id = await t.run(async (ctx) => ctx.db.insert(table as never, value as never))
+  return await t.run(async (ctx) => ctx.db.get(id))
+}
+
+export async function seedList(t: ReturnType<typeof createConvexTest>, name = 'List A') {
+  return await t.mutation(api.lists.create, { name })
+}
+
+export async function seedProfile(
+  t: ReturnType<typeof createConvexTest>,
+  overrides: Record<string, unknown> = {}
+) {
+  return await t.mutation(api.profiles.create, {
+    name: (overrides.name as string | undefined) ?? 'Profile A',
+    proxy: overrides.proxy as string | undefined,
+    proxyType: overrides.proxyType as string | undefined,
+    testIp: overrides.testIp as boolean | undefined,
+    fingerprintSeed: overrides.fingerprintSeed as string | undefined,
+    fingerprintOs: overrides.fingerprintOs as string | undefined,
+    sessionId: overrides.sessionId as string | undefined,
+    dailyScrapingLimit: overrides.dailyScrapingLimit as number | null | undefined,
+  })
+}
+
+export async function seedWorkflow(
+  t: ReturnType<typeof createConvexTest>,
+  overrides: Record<string, unknown> = {}
+) {
+  return await insertDoc(t, 'workflows', {
+    name: 'Workflow A',
+    description: 'test workflow',
+    nodes: [],
+    edges: [],
+    listIds: [],
+    status: 'idle',
+    isActive: false,
+    scheduleType: 'daily',
+    scheduleConfig: { hourUTC: 9, minuteUTC: 0 },
+    runsToday: 0,
+    retryCount: 0,
+    maxRetries: 2,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  })
+}

--- a/convex/tests/helpers/harness.ts
+++ b/convex/tests/helpers/harness.ts
@@ -1,0 +1,62 @@
+import { convexTest } from 'convex-test'
+
+import { api } from '../../_generated/api'
+import schema from '../../schema'
+
+export function createHarness() {
+  const modules = {
+    ...import.meta.glob('../../*.ts'),
+    ...import.meta.glob('../../_generated/**/*.{js,ts,d.ts}'),
+  }
+  return convexTest(schema, modules)
+}
+
+export async function insertDoc(t: any, table: string, doc: Record<string, unknown>) {
+  return await t.run(async (ctx: any) => await ctx.db.insert(table as any, doc as any))
+}
+
+export async function getDoc(t: any, id: any) {
+  return await t.run(async (ctx: any) => await ctx.db.get(id))
+}
+
+export async function listDocs(t: any, table: string) {
+  return await t.run(async (ctx: any) => await ctx.db.query(table as any).collect())
+}
+
+export async function createList(t: any, name: string = 'List') {
+  return await t.mutation(api.lists.create, { name })
+}
+
+export async function createProfile(
+  t: any,
+  overrides: Record<string, unknown> = {}
+) {
+  return await t.mutation(api.profiles.create, {
+    name: 'profile-1',
+    testIp: false,
+    ...overrides,
+  })
+}
+
+export async function createWorkflow(
+  t: any,
+  overrides: Record<string, unknown> = {}
+) {
+  return await t.mutation(api.workflows.create, {
+    name: 'Workflow',
+    nodes: [],
+    edges: [],
+    ...overrides,
+  })
+}
+
+export async function createScrapingTask(
+  t: any,
+  overrides: Record<string, unknown> = {}
+) {
+  return await t.mutation(api.scrapingTasks.create, {
+    name: 'task-1',
+    targetUsername: 'target-user',
+    ...overrides,
+  })
+}

--- a/convex/tests/http.test.ts
+++ b/convex/tests/http.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest, seedList, seedProfile, seedWorkflow } from './helpers'
+
+function stubEnv(env: Record<string, string>) {
+  vi.stubGlobal('process', { env })
+}
+
+test('rejects unauthorized requests when INTERNAL_API_KEY is configured', async () => {
+  const t = createConvexTest()
+  stubEnv({ INTERNAL_API_KEY: 'secret-token' })
+
+  const response = await t.fetch('/api/lists', { method: 'GET' })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+})
+
+test('maps list responses for authorized requests', async () => {
+  const t = createConvexTest()
+  const list = await seedList(t, 'Leads')
+  stubEnv({ INTERNAL_API_KEY: 'secret-token' })
+
+  const response = await t.fetch('/api/lists', {
+    method: 'GET',
+    headers: { authorization: 'Bearer secret-token' },
+  })
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual([{ id: list!._id, name: 'Leads' }])
+})
+
+test('parses snake_case profile payloads and maps the response back to Python fields', async () => {
+  const t = createConvexTest()
+  stubEnv({ INTERNAL_API_KEY: 'secret-token' })
+
+  const response = await t.fetch('/api/profiles', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer secret-token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: 'Profile A',
+      session_id: 'session-1',
+      daily_scraping_limit: 25,
+      test_ip: true,
+      proxy_type: 'http',
+    }),
+  })
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toMatchObject({
+    name: 'Profile A',
+    session_id: 'session-1',
+    daily_scraping_limit: 25,
+    daily_scraping_used: 0,
+    test_ip: true,
+    proxy_type: 'http',
+  })
+})
+
+test('returns a route-level validation error when workflow start is missing an id', async () => {
+  const t = createConvexTest()
+  stubEnv({ INTERNAL_API_KEY: 'secret-token' })
+
+  const response = await t.fetch('/api/workflows/start', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer secret-token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  })
+
+  expect(response.status).toBe(400)
+  await expect(response.json()).resolves.toEqual({ error: 'id is required' })
+})
+
+test('maps workflow rows through the http router', async () => {
+  const t = createConvexTest()
+  await seedWorkflow(t, { name: 'Workflow B', status: 'running' })
+  stubEnv({ INTERNAL_API_KEY: 'secret-token' })
+
+  const response = await t.fetch('/api/workflows?status=running', {
+    method: 'GET',
+    headers: { authorization: 'Bearer secret-token' },
+  })
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toHaveLength(1)
+  expect(body[0]).toMatchObject({ name: 'Workflow B', status: 'running' })
+})

--- a/convex/tests/instagramAccounts.test.ts
+++ b/convex/tests/instagramAccounts.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest, seedProfile } from './helpers'
+
+test('normalizes usernames and skips duplicates', async () => {
+  const t = createConvexTest()
+
+  const first = await t.mutation(api.instagramAccounts.insert, {
+    userName: '@User-A//',
+    status: 'available',
+    message: false,
+    createdAt: Date.now(),
+  })
+  const second = await t.mutation(api.instagramAccounts.insert, {
+    userName: 'user-a',
+    status: 'available',
+    message: false,
+    createdAt: Date.now(),
+  })
+
+  expect(first.alreadyExisted).toBe(false)
+  expect(second.alreadyExisted).toBe(true)
+})
+
+test('updates assignment state and message flags', async () => {
+  const t = createConvexTest()
+  const profile = await seedProfile(t, { name: 'Profile A' })
+  const created = await t.mutation(api.instagramAccounts.insert, {
+    userName: 'user-b',
+    status: 'available',
+    message: false,
+    createdAt: Date.now(),
+  })
+
+  const assigned = await t.mutation(api.instagramAccounts.updateStatus, {
+    accountId: created.id,
+    status: 'assigned',
+    assignedTo: profile!._id,
+  })
+  const messaged = await t.mutation(api.instagramAccounts.updateMessage, {
+    userName: 'USER-B',
+    message: true,
+  })
+  const profiles = await t.query(api.instagramAccounts.getProfilesWithAssignedAccounts, {
+    status: 'assigned',
+  })
+
+  expect(assigned).toMatchObject({
+    assignedTo: profile!._id,
+    status: 'assigned',
+  })
+  expect(messaged?.message).toBe(true)
+  expect(profiles).toHaveLength(1)
+  expect(profiles[0]?._id).toBe(profile!._id)
+})

--- a/convex/tests/inventory.test.ts
+++ b/convex/tests/inventory.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+
+import { modules } from './helpers'
+
+test('tracks the full owned convex module cohort', () => {
+  const ownedModules = Object.keys(modules)
+    .filter((path) => !path.includes('_generated'))
+    .sort()
+
+  expect(ownedModules).toEqual([
+    '../convex.config.ts',
+    '../crons.ts',
+    '../dashboard.ts',
+    '../http.ts',
+    '../instagramAccounts.ts',
+    '../keywords.ts',
+    '../lists.ts',
+    '../messageTemplates.ts',
+    '../migrations.ts',
+    '../profiles.ts',
+    '../schema.ts',
+    '../scrapingTasks.ts',
+    '../workflows.ts',
+  ])
+})

--- a/convex/tests/keywords.test.ts
+++ b/convex/tests/keywords.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest } from './helpers'
+
+test('upserts, lists, reads, and removes keyword files', async () => {
+  const t = createConvexTest()
+
+  const created = await t.mutation(api.keywords.upsert, {
+    filename: 'names.txt',
+    content: 'Alice\nBob',
+  })
+  const list = await t.query(api.keywords.list, {})
+  const content = await t.query(api.keywords.get, { filename: 'names.txt' })
+  const removed = await t.mutation(api.keywords.remove, { filename: 'names.txt' })
+  const missing = await t.query(api.keywords.get, { filename: 'names.txt' })
+
+  expect(created.updated).toBe(false)
+  expect(list).toHaveLength(1)
+  expect(content).toBe('Alice\nBob')
+  expect(removed).toEqual({ deleted: true })
+  expect(missing).toBeNull()
+})

--- a/convex/tests/lists.test.ts
+++ b/convex/tests/lists.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest, insertDoc, seedList } from './helpers'
+
+test('creates, updates, and removes lists while clearing profile links', async () => {
+  const t = createConvexTest()
+  const list = await seedList(t, 'List A')
+  const profile = await insertDoc(t, 'profiles', {
+    createdAt: Date.now(),
+    name: 'Profile A',
+    using: false,
+    testIp: false,
+    login: true,
+    mode: 'direct',
+    listIds: [list!._id],
+  })
+
+  const updated = await t.mutation(api.lists.update, {
+    id: list!._id,
+    name: 'List B',
+  })
+  const removed = await t.mutation(api.lists.remove, { id: list!._id })
+  const linkedProfile = await t.run(async (ctx) => ctx.db.get(profile!._id))
+
+  expect(updated?.name).toBe('List B')
+  expect(removed).toBe(true)
+  expect(linkedProfile?.listIds).toEqual([])
+})

--- a/convex/tests/messageTemplates.test.ts
+++ b/convex/tests/messageTemplates.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest } from './helpers'
+
+test('upserts and reads cleaned message template text arrays', async () => {
+  const t = createConvexTest()
+
+  await t.mutation(api.messageTemplates.upsert, {
+    kind: 'intro',
+    texts: ['Hello', '', '  Welcome  '],
+  })
+  const texts = await t.query(api.messageTemplates.get, { kind: 'intro' })
+
+  expect(texts).toEqual(['Hello', '  Welcome  '])
+})

--- a/convex/tests/migrations.test.ts
+++ b/convex/tests/migrations.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest, insertDoc } from './helpers'
+
+test('cleans scraper-auto-only task runtime state and resets running tasks', async () => {
+  const t = createConvexTest()
+  const task = await insertDoc(t, 'scrapingTasks', {
+    name: 'Task A',
+    kind: 'followers',
+    targetUsername: 'target-a',
+    imported: false,
+    status: 'running',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    lastOutput: {
+      mode: 'legacy',
+      resumeState: { mode: 'legacy' },
+      kept: true,
+    },
+  })
+
+  const taskCleanup = await t.mutation(api.migrations.scraperAutoOnlyApplyTaskCleanup, {
+    taskId: task!._id,
+  })
+  const cleanedTask = await t.run(async (ctx) => ctx.db.get(task!._id))
+
+  expect(taskCleanup).toMatchObject({
+    updated: true,
+    removedLegacyFields: 0,
+    resetToIdle: true,
+    clearedRuntimeState: true,
+  })
+  expect(cleanedTask).toMatchObject({
+    status: 'idle',
+    lastOutput: {
+      kept: true,
+    },
+  })
+})

--- a/convex/tests/moduleInventory.test.ts
+++ b/convex/tests/moduleInventory.test.ts
@@ -1,0 +1,28 @@
+import { readdirSync } from 'node:fs'
+
+import { expect, test } from 'vitest'
+
+const expectedModules = [
+  'convex.config.ts',
+  'crons.ts',
+  'dashboard.ts',
+  'http.ts',
+  'instagramAccounts.ts',
+  'keywords.ts',
+  'lists.ts',
+  'messageTemplates.ts',
+  'migrations.ts',
+  'profiles.ts',
+  'schema.ts',
+  'scrapingTasks.ts',
+  'workflows.ts',
+]
+
+test('matches the owned top-level convex module cohort', () => {
+  const root = new URL('../', import.meta.url)
+  const actualModules = readdirSync(root)
+    .filter((entry) => entry.endsWith('.ts'))
+    .sort()
+
+  expect(actualModules).toEqual(expectedModules)
+})

--- a/convex/tests/profiles.test.ts
+++ b/convex/tests/profiles.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest'
+
+import { api, internal } from '../_generated/api'
+import { createConvexTest, seedList, seedProfile } from './helpers'
+
+test('creates profiles and selects available profiles by list with cooldown logic', async () => {
+  const t = createConvexTest()
+  const list = await seedList(t, 'List A')
+  const profile = await seedProfile(t, {
+    name: 'Profile A',
+    proxy: 'http://proxy',
+    sessionId: ' session-1 ',
+    dailyScrapingLimit: 10,
+  })
+
+  await t.mutation(api.profiles.bulkAddToList, {
+    profileIds: [profile!._id],
+    listId: list!._id,
+  })
+
+  const available = await t.query(api.profiles.getAvailableForLists, {
+    listIds: [String(list!._id)],
+    cooldownMinutes: 10,
+  })
+
+  expect(profile).toMatchObject({
+    mode: 'proxy',
+    sessionId: 'session-1',
+    dailyScrapingLimit: 10,
+    dailyScrapingUsed: 0,
+  })
+  expect(available).toHaveLength(1)
+  expect(available[0]?._id).toBe(profile!._id)
+})
+
+test('clears busy profiles for lists and resets scraping counters', async () => {
+  const t = createConvexTest()
+  const list = await seedList(t, 'List A')
+  const profile = await seedProfile(t, { name: 'Profile B' })
+
+  await t.mutation(api.profiles.bulkAddToList, {
+    profileIds: [profile!._id],
+    listId: list!._id,
+  })
+  await t.mutation(api.profiles.syncStatus, {
+    name: 'Profile B',
+    status: 'running',
+    using: true,
+  })
+  await t.mutation(api.profiles.incrementDailyScrapingUsed, {
+    name: 'Profile B',
+    amount: 5,
+  })
+  await t.mutation(api.profiles.clearBusyForLists, {
+    listIds: [list!._id],
+  })
+  await t.mutation(internal.profiles.resetDailyScrapingUsed, {})
+
+  const updated = await t.query(api.profiles.getById, {
+    profileId: profile!._id,
+  })
+
+  expect(updated).toMatchObject({
+    status: 'idle',
+    using: false,
+    dailyScrapingUsed: 0,
+  })
+})

--- a/convex/tests/schema.test.ts
+++ b/convex/tests/schema.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest } from './helpers'
+
+test('boots convex-test against the schema and accepts table operations', async () => {
+  const t = createConvexTest()
+  const list = await t.mutation(api.lists.create, { name: 'Schema Smoke' })
+  const rows = await t.query(api.lists.list, {})
+
+  expect(list?.name).toBe('Schema Smoke')
+  expect(rows).toHaveLength(1)
+})

--- a/convex/tests/scrapingTasks.test.ts
+++ b/convex/tests/scrapingTasks.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'vitest'
+
+import { api } from '../_generated/api'
+import { createConvexTest } from './helpers'
+
+test('creates tasks, stores scraped data, and exposes storage urls', async () => {
+  const t = createConvexTest()
+  const task = await t.mutation(api.scrapingTasks.create, {
+    name: 'Task A',
+    kind: 'followers',
+    targetUsername: 'target-a',
+  })
+
+  const stored = await t.action(api.scrapingTasks.storeScrapedData, {
+    taskId: task!._id,
+    users: [{ userName: 'user-a' }],
+    metadata: { source: 'test' },
+  })
+  await t.mutation(api.scrapingTasks.setStatus, {
+    id: task!._id,
+    status: 'completed',
+    lastRunAt: Date.now(),
+    storageId: stored.storageId,
+  })
+
+  const updated = await t.query(api.scrapingTasks.getById, { id: task!._id })
+  const url = await t.query(api.scrapingTasks.getStorageUrl, {
+    storageId: stored.storageId,
+  })
+  const unimported = await t.query(api.scrapingTasks.listUnimported, {
+    kind: 'followers',
+  })
+
+  expect(stored.count).toBe(1)
+  expect(updated?.storageId).toBe(stored.storageId)
+  expect(typeof url).toBe('string')
+  expect(unimported).toHaveLength(1)
+})
+
+test('normalizes task status updates', async () => {
+  const t = createConvexTest()
+  const task = await t.mutation(api.scrapingTasks.create, {
+    name: 'Task B',
+    kind: 'followers',
+    targetUsername: 'target-b',
+  })
+
+  const updated = await t.mutation(api.scrapingTasks.setStatus, {
+    id: task!._id,
+    status: 'RUNNING',
+    lastError: ' failed ',
+  })
+
+  expect(updated).toMatchObject({
+    status: 'running',
+    lastError: 'failed',
+  })
+})

--- a/convex/tests/setup.ts
+++ b/convex/tests/setup.ts
@@ -1,0 +1,11 @@
+import { afterEach, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})

--- a/convex/tests/workflows.test.ts
+++ b/convex/tests/workflows.test.ts
@@ -1,0 +1,101 @@
+import { expect, test, vi } from 'vitest'
+
+import { api, internal } from '../_generated/api'
+import { createConvexTest, insertDoc, seedList, seedWorkflow } from './helpers'
+
+test('creates workflows, deduplicates list ids, and transitions status', async () => {
+  const t = createConvexTest()
+  const list = await seedList(t, 'List A')
+
+  const created = await t.mutation(api.workflows.create, {
+    name: '  Workflow A  ',
+    description: 'workflow',
+    nodes: [],
+    edges: [],
+    listIds: [list!._id, list!._id],
+  })
+  const started = await t.mutation(api.workflows.start, { id: created!._id })
+  const running = await t.mutation(api.workflows.updateStatus, {
+    id: created!._id,
+    status: 'running',
+    currentNodeId: 'node-1',
+    nodeStates: { 'node-1': 'running' },
+  })
+
+  expect(created).toMatchObject({
+    name: 'Workflow A',
+    listIds: [list!._id],
+  })
+  expect(started?.status).toBe('pending')
+  expect(running).toMatchObject({
+    status: 'running',
+    currentNodeId: 'node-1',
+  })
+  expect(running?.startedAt).toEqual(expect.any(Number))
+})
+
+test('executes instant workflows through scheduler and mocked fetch boundaries', async () => {
+  vi.useFakeTimers()
+
+  const t = createConvexTest()
+  const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+  vi.stubGlobal('process', {
+    env: {
+      SERVER_URL: 'http://localhost:5000',
+      INTERNAL_API_KEY: 'secret-token',
+    },
+  })
+
+  const workflow = await seedWorkflow(t, {
+    name: 'Workflow B',
+    isActive: true,
+    scheduleType: 'instant',
+    scheduleConfig: {},
+  })
+
+  const executed = await t.mutation(internal.workflows.executeScheduledWorkflow, {
+    workflowId: workflow!._id,
+  })
+  vi.runAllTimers()
+  await t.finishInProgressScheduledFunctions()
+  const updated = await t.query(api.workflows.get, { id: workflow!._id })
+
+  expect(executed).toEqual({ success: true })
+  expect(updated).toMatchObject({
+    isActive: true,
+    status: 'pending',
+    runsToday: 1,
+  })
+  expect(fetchMock).toHaveBeenCalledWith(
+    'http://localhost:5000/api/workflows/run',
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer secret-token',
+      }),
+    })
+  )
+})
+
+test('resets daily runs for active workflows', async () => {
+  const t = createConvexTest()
+  await insertDoc(t, 'workflows', {
+    name: 'Workflow C',
+    description: 'daily reset',
+    nodes: [],
+    edges: [],
+    listIds: [],
+    status: 'idle',
+    isActive: true,
+    runsToday: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })
+
+  const result = await t.mutation(internal.workflows.resetDailyRuns, {})
+  const rows = await t.query(api.workflows.list, {})
+
+  expect(result).toEqual({ reset: 1 })
+  expect(rows[0]?.runsToday).toBe(0)
+})

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,22 +1,12 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "lib": [
-            "ES2021",
-            "DOM",
-            "DOM.Iterable"
-        ],
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "noEmit": true,
-        "skipLibCheck": true
-    },
-    "include": [
-        "./**/*"
-    ],
-    "exclude": [
-        "_generated"
-    ]
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./_generated/**/*.d.ts"
+  ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,4 +44,5 @@ Conflict resolution order:
 - Keep README stubs link-first and concise.
 - Use repo-relative links only (no machine-local absolute URIs).
 - Update docs in the same change as runtime behavior changes.
+- Keep root proof commands discoverable; Convex local verification runs through `npm run test:convex`.
 - Keep drift matrix current when stale docs are discovered.

--- a/docs/convex/backend.md
+++ b/docs/convex/backend.md
@@ -48,9 +48,17 @@ Current daily jobs:
 ```bash
 npx convex dev
 npx convex deploy
+npm run test:convex
 ```
 
 Treat `convex/_generated/*` as generated artifacts.
+
+## Local Verification
+
+- `npm run test:convex` runs the isolated Convex self-test harness with `convex-test` + Vitest.
+- The local suite covers the owned top-level `convex/*.ts` cohort and excludes `convex/_generated/*`.
+- Tests must remain deterministic and local-only: no live Convex backend, no real outbound network calls, no deployed data writes.
+- Any change under `convex/` must add or update relevant tests in `convex/tests/`.
 
 ## Verified Against
 

--- a/docs/overview/developer-workflow.md
+++ b/docs/overview/developer-workflow.md
@@ -6,6 +6,7 @@ From repository root:
 - `npm run dev` (server dev mode)
 - `npm run build` (server build via root script)
 - `npm run start` (server start via root script)
+- `npm run test:convex` (Convex self-test harness via Vitest + convex-test)
 - `docker compose up --build` (full stack)
 
 Module-level:
@@ -28,6 +29,8 @@ Module-level:
 ## Testing Expectations
 
 - Python tests are `test_*.py` in `python/tests/` (unittest style, pytest-compatible execution).
+- Convex tests live under `convex/tests/` and run with `npm run test:convex`.
+- Any change touching `convex/` must add or update relevant Convex tests.
 - For frontend/server changes without dedicated tests, run lint + build.
 - Add/update tests when changing automation logic, parsing, retries, or state handling.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "convex": "^1.31.2"
       },
       "devDependencies": {
-        "typescript": "^5.9.3"
+        "@types/node": "^24.10.1",
+        "convex-test": "^0.0.41",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@convex-dev/crons": {
@@ -363,6 +366,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.4",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
@@ -427,6 +447,536 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convex": {
       "version": "1.31.2",
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.31.2.tgz",
@@ -460,6 +1010,16 @@
         }
       }
     },
+    "node_modules/convex-test": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.41.tgz",
+      "integrity": "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.16.4"
+      }
+    },
     "node_modules/cron-parser": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
@@ -471,6 +1031,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.4",
@@ -512,6 +1079,59 @@
         "@esbuild/win32-x64": "0.25.4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -543,6 +1163,102 @@
         "node": ">=12"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
@@ -572,6 +1288,126 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -584,6 +1420,650 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,13 +5,17 @@
   "scripts": {
     "build": "npm --prefix server run build",
     "dev": "npm --prefix server run dev",
-    "start": "npm --prefix server run start"
+    "start": "npm --prefix server run start",
+    "test:convex": "vitest run --config vitest.convex.config.ts"
   },
   "dependencies": {
     "@convex-dev/crons": "^0.2.0",
     "convex": "^1.31.2"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "@types/node": "^24.10.1",
+    "convex-test": "^0.0.41",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/vitest.convex.config.ts
+++ b/vitest.convex.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['convex/tests/**/*.test.ts'],
+    setupFiles: ['convex/tests/setup.ts'],
+    restoreMocks: true,
+    clearMocks: true,
+  },
+  server: {
+    deps: {
+      inline: ['convex-test'],
+    },
+  },
+})


### PR DESCRIPTION
Fixes #25

## Summary
- add root-level Convex test wiring with Vitest and convex-test
- add owned-module Convex coverage under convex/tests, including high-risk HTTP/workflow/scrapingTasks/cron scenarios
- update docs and agent guidance for npm run test:convex and the future Convex test rule

## Verification
- npm run test:convex
- npm run build
- artifacts/issue-25/convex-test-smoke.txt
- artifacts/issue-25/convex-test.txt
- artifacts/issue-25/root-build.txt